### PR TITLE
Use defaultLocale as runtimeConfig

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,6 +36,7 @@ export default defineNuxtConfig({
     public: {
       i18n: {
         baseUrl: 'https://www.data.gouv.fr/', // NUXT_PUBLIC_I18N_BASE_URL
+        defaultLocale: 'en', // NUXT_PUBLIC_I18N_DEFAULT_LOCALE
       },
 
       apiBase: 'http://dev.local:7000',
@@ -183,7 +184,6 @@ export default defineNuxtConfig({
       },
     ],
     lazy: true,
-    defaultLocale: 'en',
     strategy: 'prefix',
     trailingSlash: true,
   },


### PR DESCRIPTION
It will allow to override the config with `NUXT_PUBLIC_I18N_DEFAULT_LOCALE`.

In our case, we want to use `fr` as default locale, since `detectBrowserLanguage` is only set on `root` (ie. dev.local:3000/ that doesn't exist in our case) by default, [as recommended for SEO](https://i18n.nuxtjs.org/docs/guide/browser-language-detection).

It means, that we don't use the browser language when navigating to a page other than root `/`, for exemple `/support`.
We're then redirected to `/en/support` since `en` is the default locale by default, when most people should be redirected to `/fr/support`.
Cookie is then set with `i18n_redirected=en`, as long as the user doesn't encounter a `/fr/` route.
```
curl --head -H "Accept-Language: fr,fr-FR;q=0.8" http://dev.local:3000/support/
HTTP/1.1 302 Found
set-cookie: i18n_redirected=en; Path=/; Expires=Wed, 15 Apr 2026 14:18:12 GMT; SameSite=Lax
location: /en/support/
```

## Note
I wonder if we should apply `detectBrowserLanguage` to `redirect_on=no_prefix` at some point, even though not recommended for SEO ([see doc](https://i18n.nuxtjs.org/docs/api/options#redirecton))?