### PR TITLE
Add noindex & nofollow meta in admin

### DIFF
--- a/pages/beta/admin.vue
+++ b/pages/beta/admin.vue
@@ -95,7 +95,10 @@ const me = useMe()
 const { locale } = useI18n()
 const config = useRuntimeConfig()
 
-useSeoMeta({ title: 'Admin' })
+useSeoMeta({
+  title: 'Admin',
+  robots: 'noindex, nofollow',
+})
 
 const { organizations, users } = useCurrentOwned()
 const isSiteAdmin = computed(() => me.value.roles?.includes('admin') || false)


### PR DESCRIPTION
All pages located in admin require authentication, so this is probably useless.
However, it was present on the old udata admin so I'm adding it here as an additional safety measure.

What do you think?