### PR TITLE
Use query params instead of hash segments for resources edit routes

### DIFF
--- a/components/Datasets/FileEditModal.vue
+++ b/components/Datasets/FileEditModal.vue
@@ -150,7 +150,7 @@ onMounted(() => {
 })
 const setHash = () => {
   if (!props.resource.resource) return
-  window.history.replaceState(null, '', `${route.path}#${props.resource.resource.id}`)
+  window.history.replaceState(null, '', `${route.path}?resource_id=${props.resource.resource.id}`)
 }
 const removeHash = () => {
   if (!props.resource.resource) return

--- a/components/Datasets/FileEditModalFromHash.client.vue
+++ b/components/Datasets/FileEditModalFromHash.client.vue
@@ -19,12 +19,11 @@ const props = defineProps<{
 const { $api } = useNuxtApp()
 
 const resource = ref<ResourceForm | CommunityResourceForm | null>(null)
+const route = useRoute()
 
 onMounted(async () => {
-  const hash = window.location.hash
-  if (!hash) return
-
-  const resourceId = hash.substring(1)
+  const resourceId = route.query.resource_id
+  if (Array.isArray(resourceId) || !resourceId) return
 
   if (props.dataset) { // this is a dataset's resource
     resource.value = resourceToForm(await $api<Resource>(`/api/1/datasets/${props.dataset.id}/resources/${resourceId}/`), props.schemas)


### PR DESCRIPTION
It allows to redirect to the route from Nginx (which doesn't see hashes)