### PR TITLE
Add tag filter on reuses list page

### DIFF
--- a/pages/reuses/index.vue
+++ b/pages/reuses/index.vue
@@ -46,6 +46,7 @@ watchEffect(() => {
   q.value = route.query.q
 })
 const sort = ref((route.query.sort as string | null) || undefined)
+const tag = ref((route.query.tag as string | null) || undefined)
 const topic = ref((route.query.topic as string | null) || undefined)
 const page = ref(parseInt(route.query.page as LocationQueryValue ?? '1', 10))
 const pageSize = 21
@@ -62,6 +63,7 @@ function change(newQs: string, newTopic: string | undefined, newSort: string | u
       q: q.value,
       page: page.value,
       sort: sort.value,
+      tag: tag.value,
       topic: topic.value,
     },
   })
@@ -80,6 +82,7 @@ const { data: reuses, status } = await useAPI<PaginatedArray<Reuse>>(`/api/2/reu
     page,
     page_size: pageSize,
     sort,
+    tag,
     topic,
   },
 })


### PR DESCRIPTION
The tag filter used to work on reuse list page (even if not displayed) but does not anymore.
It is used by power users only.

Ex: https://www.data.gouv.fr/fr/reuses/?tag=opendatauniversity.