### PR TITLE
Fix double queries on load

### DIFF
--- a/composables/useCurrentOwned.ts
+++ b/composables/useCurrentOwned.ts
@@ -43,10 +43,12 @@ export function useCurrentOwned() {
   })
 
   const setCurrentOrganization = (organization: Organization) => {
+    if (currentOwnedId.value && 'organization' in currentOwnedId.value && currentOwnedId.value.organization === organization.id) return
     currentOwnedId.value = { organization: organization.id }
     organizations.value[organization.id] = organization
   }
   const setCurrentUser = (user: User) => {
+    if (currentOwnedId.value && 'user' in currentOwnedId.value && currentOwnedId.value.user === user.id) return
     currentOwnedId.value = { user: user.id }
     users.value[user.id] = user
   }


### PR DESCRIPTION
After the first API call, we set the org ID as the current one, which change the currentOrgId which is used in the params for the discussions API, so even if it's the same ID the computed is rerun, the params object change and Nuxt redo the API call.