### PR TITLE
Compress public assets

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -157,6 +157,10 @@ export default defineNuxtConfig({
   },
   compatibilityDate: '2024-04-03',
 
+  nitro: {
+    compressPublicAssets: true,
+  },
+
   vite: {
     assetsInclude: ['**/*.md'],
     css: {


### PR DESCRIPTION
We can opt-in to compress public assets at build time and it generates both gzip and brotli version of supported files.