### PR TITLE
Add missing legacy hash redirect

### DIFF
--- a/pages/dataservices/[did].vue
+++ b/pages/dataservices/[did].vue
@@ -270,6 +270,7 @@ const openSwagger = ref(false)
 onMounted(async () => {
   await redirectLegacyHashes([
     { from: 'discussions', to: `/dataservices/${route.params.did}/discussions/`, queryParam: 'discussion_id' },
+    { from: 'discussion', to: `/datasets/${route.params.did}/discussions/`, queryParam: 'discussion_id' },
   ])
 })
 </script>

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -269,6 +269,7 @@ onMounted(async () => {
     { from: 'resources', to: `/datasets/${route.params.did}/`, queryParam: 'resource_id' },
     { from: 'community-reuses', to: `/datasets/${route.params.did}/reuses_and_dataservices/` },
     { from: 'discussions', to: `/datasets/${route.params.did}/discussions/`, queryParam: 'discussion_id' },
+    { from: 'discussion', to: `/datasets/${route.params.did}/discussions/`, queryParam: 'discussion_id' },
     { from: 'community-resources', to: `/datasets/${route.params.did}/community-resources/`, queryParam: 'resource_id' },
     { from: 'information', to: `/datasets/${route.params.did}/informations/` },
   ])

--- a/pages/reuses/[rid].vue
+++ b/pages/reuses/[rid].vue
@@ -184,4 +184,11 @@ useSeoMeta({
   title,
   robots,
 })
+
+onMounted(async () => {
+  await redirectLegacyHashes([
+    { from: 'discussions', to: `/dataservices/${route.params.did}/discussions/`, queryParam: 'discussion_id' },
+    { from: 'discussion', to: `/datasets/${route.params.did}/discussions/`, queryParam: 'discussion_id' },
+  ])
+})
 </script>

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -24,6 +24,12 @@ export async function redirectLegacyHashes(instructions: Array<{ from: string, t
       await navigateTo({ path: to, query }, { redirectCode: 301 })
       return
     }
+    if (queryParam && route.hash.startsWith(`#${from}-`)) {
+      const query = {} as Record<string, string>
+      query[queryParam] = route.hash.substring(`#${from}-`.length)
+      await navigateTo({ path: to, query }, { redirectCode: 301 })
+      return
+    }
   }
 }
 


### PR DESCRIPTION
Fix link for discussions in mails 

http://www.data.gouv.fr/fr/datasets/demandes-de-valeurs-foncieres-geolocalisees/?mtm_campaign=mail-datagouv#discussion-683ebb9e72e4bba9f03fd763

Not sure why we have multiple hash-types… But let's redirect and fix these links to the new URLs later.