### PR TITLE
Add geopf extensions openlayers for WMS services

### DIFF
--- a/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
@@ -1,4 +1,11 @@
-<script setup lang = "js">
+<template>
+  <div
+    id="map"
+    ref="mapRef"
+  />
+</template>
+
+<script setup lang = "ts">
 import { onMounted, ref } from 'vue'
 
 import View from 'ol/View'
@@ -37,7 +44,8 @@ import Gp from 'geoportal-access-lib'
 let map = null
 const mapRef = ref(0)
 
-onMounted(() => {
+
+async function displayMap() {
   const cfg = new Gp.Services.Config({
     customConfigFile: 'https://raw.githubusercontent.com/IGNF/geoportal-configuration/new-url/dist/fullConfig.json',
     onSuccess: () => {
@@ -61,7 +69,6 @@ onMounted(() => {
         bar: false,
       })
       map.addControl(scaleControl)
-
       const territories = new Territories({
         collapsed: false,
         draggable: true,
@@ -247,15 +254,12 @@ onMounted(() => {
     },
   })
   cfg.call()
+}
+
+onMounted(() => {
+  displayMap()
 })
 </script>
-
-<template>
-  <div
-    id="map"
-    ref="mapRef"
-  />
-</template>
 
 <style>
   #map {

--- a/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
@@ -89,6 +89,11 @@ async function displayMap() {
   })
   map.addControl(layerSwitcher)
 
+  const attributions = new GeoportalAttribution({
+    position: 'bottom-right',
+  })
+  map.addControl(attributions)
+
   const layerImport = new LayerImport({
     position: 'bottom-left',
     listable: true,
@@ -96,6 +101,8 @@ async function displayMap() {
   })
   layerImport._serviceUrlImportInput.value = props.resource.url
   layerImport._formContainer.dispatchEvent(new CustomEvent('submit', { cancelable: true }))
+
+  map.addControl(layerImport)
 
   // Wait for GetCapabilities to be called before trying to show layer
   // TODO: use signal handling to know whether GetCapabilities failed or not 
@@ -115,13 +122,6 @@ async function displayMap() {
     }
   }
   setTimeout(showLayer, waitTimeout)
-
-  map.addControl(layerImport)
-
-  const attributions = new GeoportalAttribution({
-    position: 'bottom-right',
-  })
-  map.addControl(attributions)
 }
 
 onMounted(() => {

--- a/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
@@ -103,12 +103,14 @@ async function displayMap() {
       layerImport._formContainer.dispatchEvent(new CustomEvent('submit', { cancelable: true }))
 
       // Wait for GetCapabilities to be called before trying to show layer
-      let count = 10
+      // TODO: use signal handling to know whether GetCapabilities failed or not 
+      const waitTimeout = 500
+      let retry = 10
       function showLayer() {
         if (!layerImport._getCapResponseWMSLayers) {
-          count--
-          if (count > 0)
-            setTimeout(showLayer, 500)
+          retry--
+          if (retry > 0)
+            setTimeout(showLayer, waitTimeout)
           else
             hasError.value = true
         }
@@ -117,42 +119,14 @@ async function displayMap() {
           layerImport._addGetCapWMSLayer(layerInfo)
         }
       }
-      setTimeout(showLayer, 500)
+      setTimeout(showLayer, waitTimeout)
 
       map.addControl(layerImport)
-
-      const search = new SearchEngine({
-        displayButtonAdvancedSearch: true,
-        displayButtonGeolocate: false,
-        displayButtonCoordinateSearch: true,
-        displayButtonClose: false,
-        collapsible: false,
-        resources: {
-          search: true,
-        },
-        searchOptions: {
-          addToMap: true,
-          filterServices: 'WMTS,WMS,TMS,WFS',
-          filterLayersPriority: 'PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS',
-          filterWMTSPriority: true,
-          serviceOptions: {
-            maximumResponses: 20,
-          },
-        },
-        markerUrl: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAzNiIgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4Ij48cGF0aCBmaWxsPSIjMDAwMDkxIiBkPSJNMTguMzY0IDMuNjM2YTkgOSAwIDAgMSAwIDEyLjcyOEwxMiAyMi43MjhsLTYuMzY0LTYuMzY0QTkgOSAwIDAgMSAxOC4zNjQgMy42MzZaTTEyIDhhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00WiIvPjwvc3ZnPg==',
-      })
-      map.addControl(search)
 
       const attributions = new GeoportalAttribution({
         position: 'bottom-right',
       })
       map.addControl(attributions)
-
-      const controlList = new ControlList({
-        draggable: false,
-        position: 'bottom-right',
-      })
-      map.addControl(controlList)
     },
     onFailure: (e) => {
       console.error(e)

--- a/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
@@ -15,27 +15,13 @@ import TileLayer from 'ol/layer/Tile'
 import OSM from 'ol/source/OSM'
 
 import {
-  Catalog,
   CRS,
-  Drawing,
-  ElevationPath,
-  GetFeatureInfo,
   GeoportalAttribution,
   GeoportalFullScreen,
-  GeoportalOverviewMap,
   GeoportalZoom,
-  Isocurve,
-  MeasureArea,
-  MeasureAzimuth,
-  MeasureLength,
-  MousePosition as GeoportalMousePosition,
   LayerImport,
   LayerSwitcher,
-  Legends,
-  ReverseGeocode,
-  Route,
   SearchEngine,
-  Territories,
   ControlList,
 } from 'geopf-extensions-openlayers'
 
@@ -44,8 +30,12 @@ import Gp from 'geoportal-access-lib'
 let map = null
 const mapRef = ref(0)
 
-
 async function displayMap() {
+  await import('ol/ol.css')
+  await import('@gouvfr/dsfr/dist/dsfr.css')
+  await import('@gouvfr/dsfr/dist/utility/icons/icons.css')
+  await import('geopf-extensions-openlayers/css/Dsfr.css')
+
   const cfg = new Gp.Services.Config({
     customConfigFile: 'https://raw.githubusercontent.com/IGNF/geoportal-configuration/new-url/dist/fullConfig.json',
     onSuccess: () => {
@@ -69,97 +59,16 @@ async function displayMap() {
         bar: false,
       })
       map.addControl(scaleControl)
-      const territories = new Territories({
-        collapsed: false,
-        draggable: true,
-        position: 'top-right',
-        panel: true,
-        auto: true,
-        thumbnail: false,
-        reduce: false,
-        tiles: 3,
-      })
-      map.addControl(territories)
 
       const fullscreen = new GeoportalFullScreen({
         position: 'top-right',
       })
       map.addControl(fullscreen)
 
-      const legends = new Legends({
-        collapsed: true,
-        position: 'bottom-left',
-        panel: true,
-        auto: true,
-        info: true,
-      })
-      map.addControl(legends)
-
-      const catalog = new Catalog({
-        position: 'top-left',
-        categories: [
-          {
-            title: 'Données',
-            id: 'data',
-            items: [
-              {
-                title: 'WMTS',
-                default: true,
-                filter: {
-                  field: 'service',
-                  value: 'WMTS',
-                },
-              },
-              {
-                title: 'WMS',
-                filter: {
-                  field: 'service',
-                  value: 'WMS',
-                },
-              },
-              {
-                title: 'TMS',
-                filter: {
-                  field: 'service',
-                  value: 'TMS',
-                },
-              },
-              {
-                title: 'Tout',
-                filter: null,
-              },
-            ],
-          },
-        ],
-      })
-      map.addControl(catalog)
-
-      const drawing = new Drawing({
-        position: 'top-left',
-      })
-      map.addControl(drawing)
-
-      const overmap = new GeoportalOverviewMap({
-        position: 'bottom-left',
-      })
-      map.addControl(overmap)
-
       const zoom = new GeoportalZoom({
         position: 'bottom-left',
       })
       map.addControl(zoom)
-
-      const iso = new Isocurve({
-        position: 'bottom-left',
-        listable: true,
-      })
-      map.addControl(iso)
-
-      const layerImport = new LayerImport({
-        position: 'bottom-left',
-        listable: true,
-      })
-      map.addControl(layerImport)
 
       const layerSwitcher = new LayerSwitcher({
         options: {
@@ -168,26 +77,9 @@ async function displayMap() {
       })
       map.addControl(layerSwitcher)
 
-      const mp = new GeoportalMousePosition({
-        position: 'top-right',
-      })
-      map.addControl(mp)
-
-      const route = new Route({
-        position: 'top-right',
-        listable: true,
-      })
-      map.addControl(route)
-
-      const reverse = new ReverseGeocode({
-        position: 'top-right',
-        listable: true,
-      })
-      map.addControl(reverse)
-
       const search = new SearchEngine({
         displayButtonAdvancedSearch: true,
-        displayButtonGeolocate: true,
+        displayButtonGeolocate: false,
         displayButtonCoordinateSearch: true,
         displayButtonClose: false,
         collapsible: false,
@@ -206,37 +98,6 @@ async function displayMap() {
         markerUrl: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAzNiIgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4Ij48cGF0aCBmaWxsPSIjMDAwMDkxIiBkPSJNMTguMzY0IDMuNjM2YTkgOSAwIDAgMSAwIDEyLjcyOEwxMiAyMi43MjhsLTYuMzY0LTYuMzY0QTkgOSAwIDAgMSAxOC4zNjQgMy42MzZaTTEyIDhhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00WiIvPjwvc3ZnPg==',
       })
       map.addControl(search)
-
-      const feature = new GetFeatureInfo({
-        options: {
-          position: 'top-right',
-        },
-      })
-      map.addControl(feature)
-
-      const measureLength = new MeasureLength({
-        position: 'bottom-left',
-        listable: true,
-      })
-      map.addControl(measureLength)
-
-      const measureArea = new MeasureArea({
-        position: 'bottom-left',
-        listable: true,
-      })
-      map.addControl(measureArea)
-
-      const measureAzimuth = new MeasureAzimuth({
-        position: 'bottom-left',
-        listable: true,
-      })
-      map.addControl(measureAzimuth)
-
-      const measureProfil = new ElevationPath({
-        position: 'bottom-left',
-        listable: true,
-      })
-      map.addControl(measureProfil)
 
       const attributions = new GeoportalAttribution({
         position: 'bottom-right',

--- a/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
+++ b/datagouv-components/src/components/ResourceAccordion/MapContainer.client.vue
@@ -26,6 +26,9 @@ import {
 } from 'geopf-extensions-openlayers'
 
 import Gp from 'geoportal-access-lib'
+import type { Resource } from '../../types/resources'
+
+const props = defineProps<{ resource: Resource }>()
 
 let map = null
 const mapRef = ref(0)
@@ -76,6 +79,23 @@ async function displayMap() {
         },
       })
       map.addControl(layerSwitcher)
+
+      const layerImport = new LayerImport({
+        position: 'bottom-left',
+        listable: true,
+        layerTypes: ['WMS'],
+      })
+      layerImport._serviceUrlImportInput.value = props.resource.url
+      layerImport._formContainer.dispatchEvent(new CustomEvent('submit', { cancelable: true }))
+
+      // Wait for GetCapabilities to be called before trying to show layer
+      function showLayer() {
+        const layerInfo = layerImport._getCapResponseWMSLayers.filter(layer => layer.Name == props.resource.title)[0]
+        layerImport._addGetCapWMSLayer(layerInfo)
+      }
+      setTimeout(showLayer, 2000)
+
+      map.addControl(layerImport)
 
       const search = new SearchEngine({
         displayButtonAdvancedSearch: true,

--- a/datagouv-components/src/components/ResourceAccordion/MapContainer.vue
+++ b/datagouv-components/src/components/ResourceAccordion/MapContainer.vue
@@ -1,0 +1,265 @@
+<script setup lang = "js">
+import { onMounted, ref } from 'vue'
+
+import View from 'ol/View'
+import Map from 'ol/Map'
+import ScaleLine from 'ol/control/ScaleLine'
+import TileLayer from 'ol/layer/Tile'
+import OSM from 'ol/source/OSM'
+
+import {
+  Catalog,
+  CRS,
+  Drawing,
+  ElevationPath,
+  GetFeatureInfo,
+  GeoportalAttribution,
+  GeoportalFullScreen,
+  GeoportalOverviewMap,
+  GeoportalZoom,
+  Isocurve,
+  MeasureArea,
+  MeasureAzimuth,
+  MeasureLength,
+  MousePosition as GeoportalMousePosition,
+  LayerImport,
+  LayerSwitcher,
+  Legends,
+  ReverseGeocode,
+  Route,
+  SearchEngine,
+  Territories,
+  ControlList,
+} from 'geopf-extensions-openlayers'
+
+import Gp from 'geoportal-access-lib'
+
+let map = null
+const mapRef = ref(0)
+
+onMounted(() => {
+  const cfg = new Gp.Services.Config({
+    customConfigFile: 'https://raw.githubusercontent.com/IGNF/geoportal-configuration/new-url/dist/fullConfig.json',
+    onSuccess: () => {
+      CRS.load()
+      map = new Map({
+        target: mapRef.value,
+        layers: [
+          new TileLayer({
+            source: new OSM(),
+          }),
+        ],
+        view: new View({
+          center: [288074.8449901076, 6247982.515792289],
+          zoom: 8,
+          constrainResolution: true,
+        }),
+      })
+
+      const scaleControl = new ScaleLine({
+        units: 'metric',
+        bar: false,
+      })
+      map.addControl(scaleControl)
+
+      const territories = new Territories({
+        collapsed: false,
+        draggable: true,
+        position: 'top-right',
+        panel: true,
+        auto: true,
+        thumbnail: false,
+        reduce: false,
+        tiles: 3,
+      })
+      map.addControl(territories)
+
+      const fullscreen = new GeoportalFullScreen({
+        position: 'top-right',
+      })
+      map.addControl(fullscreen)
+
+      const legends = new Legends({
+        collapsed: true,
+        position: 'bottom-left',
+        panel: true,
+        auto: true,
+        info: true,
+      })
+      map.addControl(legends)
+
+      const catalog = new Catalog({
+        position: 'top-left',
+        categories: [
+          {
+            title: 'Données',
+            id: 'data',
+            items: [
+              {
+                title: 'WMTS',
+                default: true,
+                filter: {
+                  field: 'service',
+                  value: 'WMTS',
+                },
+              },
+              {
+                title: 'WMS',
+                filter: {
+                  field: 'service',
+                  value: 'WMS',
+                },
+              },
+              {
+                title: 'TMS',
+                filter: {
+                  field: 'service',
+                  value: 'TMS',
+                },
+              },
+              {
+                title: 'Tout',
+                filter: null,
+              },
+            ],
+          },
+        ],
+      })
+      map.addControl(catalog)
+
+      const drawing = new Drawing({
+        position: 'top-left',
+      })
+      map.addControl(drawing)
+
+      const overmap = new GeoportalOverviewMap({
+        position: 'bottom-left',
+      })
+      map.addControl(overmap)
+
+      const zoom = new GeoportalZoom({
+        position: 'bottom-left',
+      })
+      map.addControl(zoom)
+
+      const iso = new Isocurve({
+        position: 'bottom-left',
+        listable: true,
+      })
+      map.addControl(iso)
+
+      const layerImport = new LayerImport({
+        position: 'bottom-left',
+        listable: true,
+      })
+      map.addControl(layerImport)
+
+      const layerSwitcher = new LayerSwitcher({
+        options: {
+          position: 'top-right',
+        },
+      })
+      map.addControl(layerSwitcher)
+
+      const mp = new GeoportalMousePosition({
+        position: 'top-right',
+      })
+      map.addControl(mp)
+
+      const route = new Route({
+        position: 'top-right',
+        listable: true,
+      })
+      map.addControl(route)
+
+      const reverse = new ReverseGeocode({
+        position: 'top-right',
+        listable: true,
+      })
+      map.addControl(reverse)
+
+      const search = new SearchEngine({
+        displayButtonAdvancedSearch: true,
+        displayButtonGeolocate: true,
+        displayButtonCoordinateSearch: true,
+        displayButtonClose: false,
+        collapsible: false,
+        resources: {
+          search: true,
+        },
+        searchOptions: {
+          addToMap: true,
+          filterServices: 'WMTS,WMS,TMS,WFS',
+          filterLayersPriority: 'PLAN.IGN,GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1,GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2,CADASTRALPARCELS.PARCELLAIRE_EXPRESS,ORTHOIMAGERY.ORTHOPHOTOS',
+          filterWMTSPriority: true,
+          serviceOptions: {
+            maximumResponses: 20,
+          },
+        },
+        markerUrl: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAzNiIgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4Ij48cGF0aCBmaWxsPSIjMDAwMDkxIiBkPSJNMTguMzY0IDMuNjM2YTkgOSAwIDAgMSAwIDEyLjcyOEwxMiAyMi43MjhsLTYuMzY0LTYuMzY0QTkgOSAwIDAgMSAxOC4zNjQgMy42MzZaTTEyIDhhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00WiIvPjwvc3ZnPg==',
+      })
+      map.addControl(search)
+
+      const feature = new GetFeatureInfo({
+        options: {
+          position: 'top-right',
+        },
+      })
+      map.addControl(feature)
+
+      const measureLength = new MeasureLength({
+        position: 'bottom-left',
+        listable: true,
+      })
+      map.addControl(measureLength)
+
+      const measureArea = new MeasureArea({
+        position: 'bottom-left',
+        listable: true,
+      })
+      map.addControl(measureArea)
+
+      const measureAzimuth = new MeasureAzimuth({
+        position: 'bottom-left',
+        listable: true,
+      })
+      map.addControl(measureAzimuth)
+
+      const measureProfil = new ElevationPath({
+        position: 'bottom-left',
+        listable: true,
+      })
+      map.addControl(measureProfil)
+
+      const attributions = new GeoportalAttribution({
+        position: 'bottom-right',
+      })
+      map.addControl(attributions)
+
+      const controlList = new ControlList({
+        draggable: false,
+        position: 'bottom-right',
+      })
+      map.addControl(controlList)
+    },
+    onFailure: (e) => {
+      console.error(e)
+    },
+  })
+  cfg.call()
+})
+</script>
+
+<template>
+  <div
+    id="map"
+    ref="mapRef"
+  />
+</template>
+
+<style>
+  #map {
+    width: 100%;
+    height: 500px;
+  }
+</style>

--- a/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
+++ b/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
@@ -178,7 +178,14 @@
               <Preview :resource="resource" />
             </div>
             <div v-if="tab.key === 'map'">
-              <Pmtiles :resource="resource" />
+              <Pmtiles
+                v-if="hasPmtiles"
+                :resource="resource"
+              />
+              <MapContainer
+                v-if="ogcService"
+                :resource="resource"
+              />
             </div>
             <div
               v-if="tab.key === 'description'"
@@ -329,6 +336,7 @@ import EditButton from './EditButton.vue'
 import DataStructure from './DataStructure.vue'
 import Preview from './Preview.vue'
 import Pmtiles from './Pmtiles.vue'
+import MapContainer from './MapContainer.vue'
 
 const OGC_SERVICES_FORMATS = ['ogc:wfs', 'ogc:wms', 'wfs', 'wms']
 const GENERATED_FORMATS = ['parquet', 'pmtiles']
@@ -397,7 +405,7 @@ const tabsOptions = computed(() => {
     options.push({ key: 'data', label: t('Data') })
   }
 
-  if (hasPmtiles.value) {
+  if (hasPmtiles.value || ogcService.value) {
     options.push({ key: 'map', label: t('Map') })
   }
 

--- a/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
+++ b/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
@@ -183,7 +183,7 @@
                 :resource="resource"
               />
               <MapContainer
-                v-if="ogcService"
+                v-if="ogcWms"
                 :resource="resource"
               />
             </div>
@@ -338,6 +338,7 @@ import Preview from './Preview.vue'
 import Pmtiles from './Pmtiles.vue'
 
 const OGC_SERVICES_FORMATS = ['ogc:wfs', 'ogc:wms', 'wfs', 'wms']
+const OGC_WMS_FORMATS = ['ogc:wms', 'wms']
 const GENERATED_FORMATS = ['parquet', 'pmtiles']
 
 const props = withDefaults(defineProps<{
@@ -375,6 +376,7 @@ const hasPmtiles = computed(() => {
 const format = computed(() => getResourceFormatIcon(props.resource.format) ? props.resource.format : t('File'))
 
 const ogcService = computed(() => OGC_SERVICES_FORMATS.includes(props.resource.format))
+const ogcWms = computed(() => OGC_WMS_FORMATS.includes(props.resource.format))
 
 const generatedFormats = computed(() => {
   return GENERATED_FORMATS
@@ -405,7 +407,7 @@ const tabsOptions = computed(() => {
     options.push({ key: 'data', label: t('Data') })
   }
 
-  if (hasPmtiles.value || ogcService.value) {
+  if (hasPmtiles.value || ogcWms.value) {
     options.push({ key: 'map', label: t('Map') })
   }
 

--- a/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
+++ b/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
@@ -326,7 +326,7 @@ import { trackEvent } from '../../functions/matomo'
 import CopyButton from '../CopyButton.vue'
 import { useComponentsConfig } from '../../config'
 import { getOwnerName } from '../../functions/owned'
-import { getResourceFormatIcon, getResourceTitleId } from '../../functions/resources'
+import { getResourceFormatIcon, getResourceTitleId, detectOgcService } from '../../functions/resources'
 import BrandedButton from '../BrandedButton.vue'
 import { getResourceExternalUrl } from '../../functions/datasets'
 import Metadata from './Metadata.vue'
@@ -337,8 +337,6 @@ import DataStructure from './DataStructure.vue'
 import Preview from './Preview.vue'
 import Pmtiles from './Pmtiles.vue'
 
-const OGC_SERVICES_FORMATS = ['ogc:wfs', 'ogc:wms', 'wfs', 'wms']
-const OGC_WMS_FORMATS = ['ogc:wms', 'wms']
 const GENERATED_FORMATS = ['parquet', 'pmtiles']
 
 const props = withDefaults(defineProps<{
@@ -375,8 +373,9 @@ const hasPmtiles = computed(() => {
 
 const format = computed(() => getResourceFormatIcon(props.resource.format) ? props.resource.format : t('File'))
 
-const ogcService = computed(() => OGC_SERVICES_FORMATS.includes(props.resource.format))
-const ogcWms = computed(() => OGC_WMS_FORMATS.includes(props.resource.format))
+const ogcService = computed(() => detectOgcService(props.resource))
+
+const ogcWms = computed(() => ogcService.value === 'wms')
 
 const generatedFormats = computed(() => {
   return GENERATED_FORMATS

--- a/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
+++ b/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
@@ -336,7 +336,6 @@ import EditButton from './EditButton.vue'
 import DataStructure from './DataStructure.vue'
 import Preview from './Preview.vue'
 import Pmtiles from './Pmtiles.vue'
-import MapContainer from './MapContainer.vue'
 
 const OGC_SERVICES_FORMATS = ['ogc:wfs', 'ogc:wms', 'wfs', 'wms']
 const GENERATED_FORMATS = ['parquet', 'pmtiles']
@@ -356,6 +355,7 @@ const props = withDefaults(defineProps<{
 const config = useComponentsConfig()
 
 const Swagger = defineAsyncComponent(() => import('./Swagger.vue'))
+const MapContainer = defineAsyncComponent(() => import('./MapContainer.client.vue'))
 
 const { t } = useI18n()
 const { formatRelativeIfRecentDate } = useFormatDate()

--- a/datagouv-components/src/functions/resources.ts
+++ b/datagouv-components/src/functions/resources.ts
@@ -104,3 +104,21 @@ export const getResourceLabel = (type: ResourceType) => {
       return t('Other')
   }
 }
+
+export const OGC_SERVICES_FORMATS = ['wfs', 'wms']
+
+export const detectOgcService = (resource: Resource) => {
+  // Detect OGC Services either based on format or a URL with GetCapabilities and known REQUEST type
+  // Return the format if found else false
+  const format = resource.format.replace(/^ogc:/, '')
+  if (OGC_SERVICES_FORMATS.includes(format))
+    return format
+  const url = resource.url.toLowerCase()
+  if (url.includes('request=getcapabilities')) {
+    for (const format of OGC_SERVICES_FORMATS)
+      if (url.includes(`service=${format}`)) {
+        return format
+      }
+  }
+  return false
+}

--- a/datagouv-components/src/functions/resources.ts
+++ b/datagouv-components/src/functions/resources.ts
@@ -110,9 +110,11 @@ export const OGC_SERVICES_FORMATS = ['wfs', 'wms']
 export const detectOgcService = (resource: Resource) => {
   // Detect OGC Services either based on format or a URL with GetCapabilities and known REQUEST type
   // Return the format if found else false
-  const format = resource.format.replace(/^ogc:/, '')
-  if (OGC_SERVICES_FORMATS.includes(format))
-    return format
+  if (resource.format) {
+    const format = resource.format.replace(/^ogc:/, '')
+    if (OGC_SERVICES_FORMATS.includes(format))
+      return format
+  }
   const url = resource.url.toLowerCase()
   if (url.includes('request=getcapabilities')) {
     for (const format of OGC_SERVICES_FORMATS)

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,8 @@
         "axios": "^1.8.2",
         "crisp-api": "^9.9.0",
         "dayjs": "^1.11.13",
+        "geopf-extensions-openlayers": "^1.0.0-beta.4",
+        "geoportal-access-lib": "^3.4.6",
         "gray-matter": "^4.0.3",
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",
@@ -2678,6 +2680,30 @@
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-style-spec": {
+      "version": "14.8.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-14.8.0.tgz",
+      "integrity": "sha512-wA4uBTrvvcSeeBKDGcjzX2XwSqpQxzv0siTduKJxIhlC68yZmWXx700rK5Rnv7+zd/neniAJZO56+vrUDwnixA==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.1",
+        "cheap-ruler": "^4.0.0",
+        "csscolorparser": "~1.0.2",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.6",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-composite": "bin/gl-style-composite.js",
+        "gl-style-format": "bin/gl-style-format.js",
+        "gl-style-migrate": "bin/gl-style-migrate.js",
+        "gl-style-validate": "bin/gl-style-validate.js"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -5370,6 +5396,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -8181,6 +8213,12 @@
         "types-ramda": "^0.30.1"
       }
     },
+    "node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -8949,6 +8987,15 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/abbrev": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.0.tgz",
@@ -9030,6 +9077,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha512-ewaIr5y+9CUTGFwZfpECUbFlGcC0GCw1oqR9RI6h1gQCd9Aj2GxSckCnPsVJnmfMZbwFYE+leZGASgkWl06Jow==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-wrap": "0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
@@ -9048,6 +9107,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ansis": {
@@ -9760,6 +9828,12 @@
         "pnpm": ">=8"
       }
     },
+    "node_modules/cheap-ruler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.0.0.tgz",
+      "integrity": "sha512-0BJa8f4t141BYKQyn9NSQt1PguFQXMXwZiA5shfoaBYHAb2fFk2RAX+tiWMoQU+Agtzt3mdt0JtuyshAXqZ+Vw==",
+      "license": "ISC"
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "license": "MIT",
@@ -9950,6 +10024,20 @@
         "@codemirror/view": "^6.0.0"
       }
     },
+    "node_modules/coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "license": "MIT",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "license": "MIT",
@@ -10073,6 +10161,60 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "license": "ISC",
+      "dependencies": {
+        "source-map": "^0.6.1"
+      }
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -10324,6 +10466,12 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
+      "license": "MIT"
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -10658,6 +10806,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diacritics-map": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+      "integrity": "sha512-3omnDTYrGigU0i4cJjvaKwD52B8aoqyX/NEIkukFFkogBemsIbhSa1O414fpTp5nuszJG6lvQ5vBvDVNCbSsaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/diff": {
@@ -11031,6 +11188,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.1",
@@ -11690,6 +11853,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventbusjs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eventbusjs/-/eventbusjs-0.2.0.tgz",
+      "integrity": "sha512-sWVRmz1cC+ImUH4PYl67SBVogPqYeIVlufi1bTBuxVcnQTwjHXviZbx38XhY2iPCm+UO7akwpnOY5h6WGxO6pg==",
+      "license": "MIT"
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -11717,6 +11886,70 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-range/node_modules/fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-range/node_modules/is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-range/node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expand-range/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expand-template": {
@@ -12015,6 +12248,15 @@
         }
       }
     },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -12150,6 +12392,83 @@
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "license": "ISC"
+    },
+    "node_modules/geopf-extensions-openlayers": {
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/geopf-extensions-openlayers/-/geopf-extensions-openlayers-1.0.0-beta.4.tgz",
+      "integrity": "sha512-DyxtITqIU+8ZdubcOHnkXRZAHtpKH2VdrD/vaP0oKUHbu5lNt/ZLAWgqK0EbVmYWkIHZvDWfEiqzLGgueD7hbg==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@gouvfr/dsfr": "^1.11.0",
+        "@mapbox/mapbox-gl-style-spec": "14.8.0",
+        "@xmldom/xmldom": "^0.9.0",
+        "eventbusjs": "0.2.0",
+        "geoportal-access-lib": "3.4.6",
+        "loglevel": "^1.9.1",
+        "markdown-toc": "^1.2.0",
+        "ol": "^10.3.1",
+        "ol-contextmenu": "^5.5.0",
+        "ol-mapbox-style": "^12.3.5",
+        "proj4": "2.15.0",
+        "sortablejs": "1.15.3",
+        "typescript": "^5.3.3",
+        "whatwg-fetch": "3.6.20",
+        "yargs": "^17.7.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/geopf-extensions-openlayers/node_modules/sortablejs": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.3.tgz",
+      "integrity": "sha512-zdK3/kwwAK1cJgy1rwl1YtNTbRmc8qW/+vgXf75A7NHag5of4pyI6uK86ktmQETyWRH7IGaE73uZOOBcGxgqZg==",
+      "license": "MIT"
+    },
+    "node_modules/geoportal-access-lib": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/geoportal-access-lib/-/geoportal-access-lib-3.4.6.tgz",
+      "integrity": "sha512-TC0NKVHcJZ9QvkEDyuMB327lT0xQIcZoIE3aSNOHN4Bkt1TcF+D/zAMQTl2AVTAYdrLAqFl6bhTWn5r7VJvkpw==",
+      "license": "CECILL-B",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.6",
+        "es6-promise": "^4.2.4",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/geotiff": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -12487,6 +12806,18 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "deprecated": "Removed event-stream from gulp-header",
+      "license": "MIT",
+      "dependencies": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
       }
     },
     "node_modules/gzip-size": {
@@ -13102,6 +13433,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-builtin-module": {
       "version": "3.2.1",
       "dev": true,
@@ -13258,6 +13595,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -13347,6 +13696,15 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -13567,6 +13925,18 @@
         "shell-quote": "^1.8.1"
       }
     },
+    "node_modules/lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha512-7vp2Acd2+Kz4XkzxGxaB1FWOi8KjWIWsgdfD5MCb86DWvlLqhRPM+d6Pro3iNEL5VT9mstz5hKAlcd+QR6H3aA==",
+      "license": "MIT",
+      "dependencies": {
+        "set-getter": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/lazystream": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -13610,6 +13980,12 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -13870,6 +14246,45 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/list-item": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "integrity": "sha512-S3D0WZ4J6hyM8o5SNKWaMYB1ALSacPZ2nHGEuCjmHZ+dc03gFeNZoNDcqfcnO4vDhTZmNrqrpYZCdXsRh22bzw==",
+      "license": "MIT",
+      "dependencies": {
+        "expand-range": "^1.8.1",
+        "extend-shallow": "^2.0.1",
+        "is-number": "^2.1.0",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/list-item/node_modules/is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/list-item/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/listhen": {
       "version": "1.9.0",
       "license": "MIT",
@@ -13960,6 +14375,12 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
       "dev": true,
@@ -13995,6 +14416,26 @@
       "version": "4.6.2",
       "license": "MIT"
     },
+    "node_modules/lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "deprecated": "This package is deprecated. Use https://socket.dev/npm/package/eta instead.",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "node_modules/lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
       "license": "MIT"
@@ -14003,6 +14444,19 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -14076,6 +14530,12 @@
         "source-map-js": "^1.2.0"
       }
     },
+    "node_modules/mapbox-to-css-font": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-3.2.0.tgz",
+      "integrity": "sha512-kvsEfzvLik34BiFj+S19bv5d70l9qSdkUzrq99dvZ9d5POaLyB4vJMQmq3BoJ5D6lFG1GYnMM7o7cm5Jh8YEEg==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/maplibre-gl": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.5.0.tgz",
@@ -14132,6 +14592,15 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-link": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+      "integrity": "sha512-TurLymbyLyo+kAUUAV9ggR9EPcDjP/ctlv9QAFiqUH7c+t6FlsbivPo9OKTU8xdOx9oNd2drW/Fi5RRElQbUqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "license": "MIT",
@@ -14140,12 +14609,107 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/markdown-toc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+      "integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "^1.5.2",
+        "diacritics-map": "^0.1.0",
+        "gray-matter": "^2.1.0",
+        "lazy-cache": "^2.0.2",
+        "list-item": "^1.1.1",
+        "markdown-link": "^0.1.1",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "object.pick": "^1.2.0",
+        "remarkable": "^1.7.1",
+        "repeat-string": "^1.6.1",
+        "strip-color": "^0.1.0"
+      },
+      "bin": {
+        "markdown-toc": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/markdown-toc/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/markdown-toc/node_modules/autolinker": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha512-zQAFO1Dlsn69eXaO6+7YZc+v84aquQKbwpzCE3L0stj56ERn9hutFxPopViLjo9G+rWwjozRhgS5KJ25Xy19cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "gulp-header": "^1.7.1"
+      }
+    },
+    "node_modules/markdown-toc/node_modules/gray-matter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+      "integrity": "sha512-vbmvP1Fe/fxuT2QuLVcqb2BfK7upGhhbLIt9/owWEvPYrZZEkelLcq2HqzxosV+PQ67dUFLaAeNpH7C4hhICAA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-red": "^0.1.1",
+        "coffee-script": "^1.12.4",
+        "extend-shallow": "^2.0.1",
+        "js-yaml": "^3.8.1",
+        "toml": "^2.3.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/markdown-toc/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/markdown-toc/node_modules/remarkable": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
+      },
+      "bin": {
+        "remarkable": "bin/remarkable.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "license": "MIT"
     },
     "node_modules/mdast-util-definitions": {
       "version": "6.0.0",
@@ -14410,6 +14974,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.1",
@@ -15075,6 +15645,31 @@
     "node_modules/mitt": {
       "version": "3.0.1",
       "license": "MIT"
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "license": "MIT",
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/mkdirp": {
       "version": "3.0.1",
@@ -16089,6 +16684,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ofetch": {
       "version": "1.4.1",
       "license": "MIT",
@@ -16101,6 +16708,64 @@
     "node_modules/ohash": {
       "version": "1.1.6",
       "license": "MIT"
+    },
+    "node_modules/ol": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.5.0.tgz",
+      "integrity": "sha512-nHFx8gkGmvYImsa7iKkwUnZidd5gn1XbMZd9GNOorvm9orjW9gQvT3Naw/MjIasVJ3cB9EJUdCGR2EFAulMHsQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^2.1.3",
+        "pbf": "4.0.1",
+        "rbush": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/ol-contextmenu": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/ol-contextmenu/-/ol-contextmenu-5.5.0.tgz",
+      "integrity": "sha512-IglB0OfzSmcP++dykqrQU62lJAn/4O61hxyD0s5V03HE70Efm6EgSaNq8YOlgEbnqfUL+7F3fS7VI3UV+0+NZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-emitter": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "ol": "> 7.x <= 10.x"
+      }
+    },
+    "node_modules/ol-mapbox-style": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.6.1.tgz",
+      "integrity": "sha512-bpN7ZvqbQX/JZnru0MTQgPIAUBAgPOvYDj/9BoJoqCvFYjHxCpRFDQJEoD10PLw3vGHNJFYBUvY82yfW26otQg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^23.1.0",
+        "mapbox-to-css-font": "^3.1.2"
+      },
+      "peerDependencies": {
+        "ol": "*"
+      }
+    },
+    "node_modules/ol/node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
     },
     "node_modules/on-change": {
       "version": "5.0.1",
@@ -16316,6 +16981,12 @@
       "version": "0.2.9",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "license": "MIT",
@@ -16357,6 +17028,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
     },
     "node_modules/parse-imports": {
       "version": "2.2.1",
@@ -17326,6 +18003,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/proj4": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.15.0.tgz",
+      "integrity": "sha512-LqCNEcPdI03BrCHxPLj29vsd5afsm+0sV1H/O3nTDKrv8/LA01ea1z4QADDMjUqxSXWnrmmQDjqFm1J/uZ5RLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.4.0"
+      }
+    },
     "node_modules/promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -17622,6 +18309,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/randomatic/node_modules/is-number": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+      "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "license": "MIT",
@@ -17635,6 +18345,15 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^3.0.0"
       }
     },
     "node_modules/rc": {
@@ -18395,6 +19114,15 @@
     "node_modules/remove-markdown": {
       "version": "0.6.0",
       "license": "MIT"
+    },
+    "node_modules/repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/repeat-string": {
       "version": "1.6.1",
@@ -19291,6 +20019,18 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-getter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+      "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
+      "license": "MIT",
+      "dependencies": {
+        "to-object-path": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
@@ -19766,6 +20506,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-color": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha512-p9LsUieSjWNNAxVCXLeilaDlmuUOrDS5/dF9znM1nZc7EGX5+zEFC0bEevsNIaldjlks+2jns5Siz6F9iK6jwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
       "license": "MIT",
@@ -20164,6 +20913,52 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -20200,6 +20995,30 @@
         "@popperjs/core": "^2.9.0"
       }
     },
+    "node_modules/to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-object-path/node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "license": "MIT",
@@ -20221,6 +21040,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toml": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
+      "license": "MIT"
     },
     "node_modules/tosource": {
       "version": "2.0.0-alpha.3",
@@ -20354,6 +21179,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/types-ramda": {
       "version": "0.30.1",
@@ -21909,6 +22740,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "license": "BSD-2-Clause"
@@ -21922,6 +22759,12 @@
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
     },
     "node_modules/whatwg-url": {
@@ -21944,6 +22787,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.2.tgz",
+      "integrity": "sha512-1ZUiV1FTwSiSrgWzV9KXJuOF2BVW91KY/mau04BhnmgOdroRQea7Q0s5TVqwGLm0D2tZwObd/tBYXW49sSxp3Q==",
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
@@ -22025,6 +22874,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.0.0",
@@ -22204,6 +23059,12 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "license": "MIT AND BSD-3-Clause"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "crisp-api": "^9.9.0",
         "dayjs": "^1.11.13",
         "geopf-extensions-openlayers": "^1.0.0-beta.4",
-        "geoportal-access-lib": "^3.4.6",
         "gray-matter": "^4.0.3",
         "leaflet": "^1.9.4",
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "mitt": "^3.0.1",
         "nuxt": "^3.16.1",
         "ofetch": "^1.4.1",
+        "ol": "^10.5.0",
         "popmotion": "^8.7.6",
         "rehype-highlight": "^7.0.1",
         "rehype-raw": "^7.0.0",
@@ -12394,9 +12395,9 @@
       "license": "ISC"
     },
     "node_modules/geopf-extensions-openlayers": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/geopf-extensions-openlayers/-/geopf-extensions-openlayers-1.0.0-beta.4.tgz",
-      "integrity": "sha512-DyxtITqIU+8ZdubcOHnkXRZAHtpKH2VdrD/vaP0oKUHbu5lNt/ZLAWgqK0EbVmYWkIHZvDWfEiqzLGgueD7hbg==",
+      "version": "1.0.0-beta.4-384",
+      "resolved": "file:../geopf-extensions-openlayers/dist/package/geopf-extensions-openlayers.tgz",
+      "integrity": "sha512-54iGr+1QPzLhRGnbK0vtjRu9641wUu5yJOelTv10W11FLtZL0Q4S/WibfwRs+UmU3LyuQQix01nQ1G09KUWTeg==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@gouvfr/dsfr": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "axios": "^1.8.2",
     "crisp-api": "^9.9.0",
     "dayjs": "^1.11.13",
+    "geopf-extensions-openlayers": "^1.0.0-beta.4",
+    "geoportal-access-lib": "^3.4.6",
     "gray-matter": "^4.0.3",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "crisp-api": "^9.9.0",
     "dayjs": "^1.11.13",
     "geopf-extensions-openlayers": "^1.0.0-beta.4",
-    "geoportal-access-lib": "^3.4.6",
     "gray-matter": "^4.0.3",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mitt": "^3.0.1",
     "nuxt": "^3.16.1",
     "ofetch": "^1.4.1",
+    "ol": "^10.5.0",
     "popmotion": "^8.7.6",
     "rehype-highlight": "^7.0.1",
     "rehype-raw": "^7.0.0",


### PR DESCRIPTION
Add [geopf-extensions-openlayers](https://github.com/IGNF/geopf-extensions-openlayers) to display WMS services.

## Notes

- MapContainer is client only and loaded async
- The library is very intertwined between the business logic & the DOM, thus using `submit` event
- We're current lacking events communication between the library and cdata to know when/if the layers description were found and then showed with success
    - We're using a naive retry strategy before displaying an error
- The user experience is quite frustrating since you can't know when a map will show or not before opening the accordeon
    - the `RiEarthLine` icon being displayed for WFS as well, which aren't supported yet
    - the `RiEarthLine` icon is not shown for resources with improper format but a URL detected as WMS 