### PR TITLE
Prevent sending too many resources in parallel

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -110,6 +110,7 @@ export default defineNuxtConfig({
 
       newsletterSubscriptionUrl: 'https://qvo970cr.sibpages.com/',
 
+      maxNumberOfResourcesToUploadInParallel: 3,
       resourceFileUploadChunk: 2 * 1000 * 1000,
       maxSortableFiles: 50,
 

--- a/pages/admin/datasets/new.vue
+++ b/pages/admin/datasets/new.vue
@@ -135,10 +135,9 @@ async function save() {
       body: JSON.stringify(datasetToApi(datasetForm.value, { private: true })),
     })
 
-    const tasks = resources.value.map((_, i: number) => saveResourceForm(dataset, resources.value[i]))
     let results: Array<PromiseSettledResult<Resource>> = []
-    for (const chunk of chunkArray(tasks, config.public.maxNumberOfResourcesToUploadInParallel)) {
-      results = [...results, ...await Promise.allSettled(chunk)]
+    for (const chunk of chunkArray(resources.value, config.public.maxNumberOfResourcesToUploadInParallel)) {
+      results = [...results, ...await Promise.allSettled(chunk.map((_, i: number) => saveResourceForm(dataset, resources.value[i])))]
     }
 
     if (results.every(f => f.status !== 'rejected')) {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -58,3 +58,11 @@ export async function useJsonLd(type: 'dataset' | 'dataservice' | 'organization'
     ],
   })
 }
+
+export function chunkArray<T>(array: T[], size: number): T[][] {
+  const result: T[][] = []
+  for (let i = 0; i < array.length; i += size) {
+    result.push(array.slice(i, i + size))
+  }
+  return result
+}


### PR DESCRIPTION
This PR is linked to https://github.com/opendatateam/udata/pull/3338 (but do not require it)

Without this PR, the udata PR will work but will print "failing to save resource after x retry" because we send too many files in a short time and the retry strategy doesn't manage to find a window to update the resource. By chunking we reduce this problem.