### PR TITLE
csv.gz is a table

### DIFF
--- a/datagouv-components/src/functions/resources.ts
+++ b/datagouv-components/src/functions/resources.ts
@@ -64,6 +64,8 @@ export function getResourceFormatIcon(format: string): Component | null {
     case 'xlsx':
     case 'parquet':
       return Table
+    case 'csv.gz':
+      return Table
     case 'geojson':
       return RiMap2Line
     case 'ogc:wfs':


### PR DESCRIPTION
I am not sure why `csv`, `xls` etc. do not return `Table` bt still display the right icon 🤔 