### PR TITLE
fix: proper French and international-ready file size formatting

### DIFF
--- a/datagouv-components/src/functions/helpers.ts
+++ b/datagouv-components/src/functions/helpers.ts
@@ -1,16 +1,17 @@
 import { useI18n } from 'vue-i18n'
 
 export const filesize = (val: number) => {
-  const { t } = useI18n()
-  const suffix = t('O')
+  const { t, locale } = useI18n()
+  const suffix = t('o')
+  const formatter = new Intl.NumberFormat(locale.value, { minimumFractionDigits: 1, maximumFractionDigits: 1 })
   const units = ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']
   for (const unit of units) {
     if (Math.abs(val) < 1024.0) {
-      return `${val.toFixed(1)}${unit}${suffix}`
+      return `${formatter.format(val)} ${unit}${suffix}`.trim()
     }
     val /= 1024.0
   }
-  return `${val.toFixed(1)}Y${suffix}`
+  return `${formatter.format(val)} Y${suffix}`.trim()
 }
 
 export const summarize = (val: number, fractionDigits = 0) => {


### PR DESCRIPTION
## Changes
- Translation key: Changed from t('O') to t('o') to comply with French unit notation
- Spacing: Added space between number and unit (e.g., 61.6 Mo instead of 61.6Mo)
- Decimal formatting: Replaced manual locale logic with Intl.NumberFormat for proper decimal separators
## Examples
- Before: 61.6MO (no space, uppercase O, period)
- After: 61,6 Mo (space, lowercase o, comma for French)
## Benefits
- Proper French formatting with comma decimal separator
- Future-proof for English (61.6 MB) and other locales
- Uses browser's built-in locale-aware number formatting

Before:
<img width="400" alt="Screenshot 2025-07-04 at 11 21 14" src="https://github.com/user-attachments/assets/663f1af5-7566-437c-a5ee-ad07d34cb1cc" />


After:
<img width="412" alt="Screenshot 2025-07-04 at 11 35 08" src="https://github.com/user-attachments/assets/8fd367af-f704-4325-a2ae-dcd3d599ae43" />
