### PR TITLE
Improve preview UI

### DIFF
--- a/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
+++ b/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
@@ -440,7 +440,7 @@ const tabsOptions = computed(() => {
   }
 
   if (hasTabularData.value || hasPreview.value) {
-    options.push({ key: 'data', label: t('Données') })
+    options.push({ key: 'data', label: t('Aperçu') })
   }
 
   if (props.resource.description) {

--- a/datagouv-components/src/components/ResourceAccordion/XmlPreview.vue
+++ b/datagouv-components/src/components/ResourceAccordion/XmlPreview.vue
@@ -1,22 +1,7 @@
 <template>
   <div class="fr-text--xs">
     <div v-if="xmlData">
-      <XmlViewer
-        :xml="xmlData"
-        theme="light"
-        :indent-width="2"
-        :show-line-numbers="true"
-        :show-attributes="true"
-        :show-comments="true"
-        :show-cdata="true"
-        :show-doctype="true"
-        :show-processing-instructions="true"
-        :show-text-nodes="true"
-        :show-whitespace="false"
-        :expand-all="false"
-        :max-depth="3"
-        :expand-depth="1"
-      />
+      <XmlViewer :xml="xmlData" />
     </div>
     <div
       v-else-if="loading"

--- a/datagouv-components/src/types/vue3-xml-viewer.d.ts
+++ b/datagouv-components/src/types/vue3-xml-viewer.d.ts
@@ -4,18 +4,6 @@ declare module 'vue3-xml-viewer' {
   export interface XmlViewerProps {
     xml: string
     theme?: 'light' | 'dark'
-    indentWidth?: number
-    showLineNumbers?: boolean
-    showAttributes?: boolean
-    showComments?: boolean
-    showCdata?: boolean
-    showDoctype?: boolean
-    showProcessingInstructions?: boolean
-    showTextNodes?: boolean
-    showWhitespace?: boolean
-    expandAll?: boolean
-    maxDepth?: number
-    expandDepth?: number
   }
 
   export const XmlViewer: Component<XmlViewerProps>


### PR DESCRIPTION
- Change naming of tab title "Données" to "Aperçu"
- Remove non-existent properties from `XmlViewerProps` interface. Component only supports `xml` and `theme` properties (unfortunately) - meaning it can't be collapsed or partly collapsed by default