### PR TITLE
Show closed discussions count on the discussions tab of public pages

### DIFF
--- a/components/Discussions/DiscussionsList.vue
+++ b/components/Discussions/DiscussionsList.vue
@@ -43,6 +43,9 @@
       >
         <h2 class="text-sm font-bold uppercase m-0 text-gray-title">
           {{ t('{n} discussions | {n} discussion | {n} discussions', pageData.total) }}
+          <template v-if="closed">
+            {{ t('dont {n} clotûrées | dont {n} clotûrée | dont {n} clotûrées', closed) }}
+          </template>
         </h2>
 
         <div>
@@ -117,6 +120,7 @@ import type { DiscussionSortedBy, DiscussionSubject, DiscussionSubjectTypes, Thr
 const props = defineProps<{
   type: DiscussionSubject['class']
   subject: DiscussionSubjectTypes
+  closed?: number
 }>()
 
 const { t } = useI18n()
@@ -146,7 +150,6 @@ const showDiscussionForm = () => {
 const params = computed(() => {
   const query = {
     sort: sortDirection.value,
-
     page_size: pageSize.value,
     page: page.value,
   } as Record<string, string | number | null | boolean>

--- a/datagouv-components/src/types/dataservices.ts
+++ b/datagouv-components/src/types/dataservices.ts
@@ -56,7 +56,7 @@ export type Dataservice = Owned & {
   machine_documentation_url: string | null
   technical_documentation_url: string | null
   business_documentation_url: string | null
-  extras: Record<string, any>
+  extras: Record<string, unknown>
   format: string
   harvest: Harvest
   id: string
@@ -64,7 +64,13 @@ export type Dataservice = Owned & {
   access_audiences: Array<DataserviceAccessAudience>
   license: string | null
   metadata_modified_at: string
-  metrics: { discussions: number, followers: number, reuses: number, views: number }
+  metrics: {
+    discussions: number
+    discussions_open: number
+    followers: number
+    reuses: number
+    views: number
+  }
   permissions: { edit: boolean, delete: boolean }
   private: boolean
   rate_limiting: string

--- a/datagouv-components/src/types/datasets.ts
+++ b/datagouv-components/src/types/datasets.ts
@@ -70,13 +70,14 @@ export type Dataset = BaseDataset & {
   quality: Quality
   metrics: {
     discussions: number
+    discussions_open: number
     followers: number
     resources_downloads: number
     reuses: number
     views: number
   }
   harvest: Harvest
-  extras: Record<string, any>
+  extras: Record<string, unknown>
   permissions: { edit: boolean, edit_resources: boolean, delete: boolean }
 
 }

--- a/datagouv-components/src/types/reuses.ts
+++ b/datagouv-components/src/types/reuses.ts
@@ -21,7 +21,7 @@ export type Reuse = BaseReuse & {
   datasets: Array<Dataset>
   archived: string | null
   deleted: string | null
-  extras: Record<string, any>
+  extras: Record<string, unknown>
   featured: boolean
   id: string
   image: string | null
@@ -30,6 +30,7 @@ export type Reuse = BaseReuse & {
   metrics: {
     datasets: number
     discussions: number
+    discussions_open: number
     followers: number
     views: number
   }

--- a/pages/dataservices/[did]/discussions.vue
+++ b/pages/dataservices/[did]/discussions.vue
@@ -2,6 +2,7 @@
   <DiscussionsList
     :subject="dataservice"
     type="Dataservice"
+    :closed
   />
 </template>
 
@@ -9,5 +10,8 @@
 import type { Dataservice } from '@datagouv/components-next'
 import DiscussionsList from '~/components/Discussions/DiscussionsList.vue'
 
-defineProps<{ dataservice: Dataservice }>()
+const props = defineProps<{ dataservice: Dataservice }>()
+const closed = computed(() => props.dataservice.metrics.discussions - props.dataservice.metrics.discussions_open)
+
+useSeoMeta({ robots: 'noindex' })
 </script>

--- a/pages/datasets/[did]/discussions.vue
+++ b/pages/datasets/[did]/discussions.vue
@@ -2,6 +2,7 @@
   <DiscussionsList
     :subject="dataset"
     type="Dataset"
+    :closed
   />
 </template>
 
@@ -9,7 +10,8 @@
 import type { DatasetV2 } from '@datagouv/components-next'
 import DiscussionsList from '~/components/Discussions/DiscussionsList.vue'
 
-defineProps<{ dataset: DatasetV2 }>()
+const props = defineProps<{ dataset: DatasetV2 }>()
+const closed = computed(() => props.dataset.metrics.discussions - props.dataset.metrics.discussions_open)
 
 useSeoMeta({ robots: 'noindex' })
 </script>

--- a/pages/reuses/[rid]/discussions.vue
+++ b/pages/reuses/[rid]/discussions.vue
@@ -1,14 +1,19 @@
 <template>
   <DiscussionsList
-    type="Reuse"
     :subject="reuse"
+    type="Reuse"
+    :closed
   />
 </template>
 
 <script setup lang="ts">
 import type { Reuse } from '@datagouv/components-next'
 
-defineProps<{
+const props = defineProps<{
   reuse: Reuse
 }>()
+const closed = computed(() => props.reuse.metrics.discussions - props.reuse.metrics.discussions_open)
+console.log(closed)
+
+useSeoMeta({ robots: 'noindex' })
 </script>


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1798

This PR requires https://github.com/opendatateam/udata/pull/3370 and a run of `count_discussions` for datasets at least.