### PR TITLE
feat: JSON preview until 1MB JSON files

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -29,9 +29,9 @@ app.vueApp.use(datagouv, {
   customUseFetch: useAPI as UseFetchFunction, // Why this `as` is required?
   textClamp: TextClamp,
   appLink: NuxtLinkLocale,
-  maxJsonPreviewSize: 100000, // Maximum size of JSON to preview in characters (~100KB)
+  maxJsonPreviewSize: 1000000, // Maximum size of JSON to preview in characters (~1MB). JSON preview module is partly collapsed by default so we can have a preview for large files.
   maxPdfPreviewSize: 10000000, // Maximum size of PDF to preview in bytes (10 MB)
-  maxXmlPreviewSize: 100000, // Maximum size of XML to preview in characters (~100KB)
+  maxXmlPreviewSize: 100000, // Maximum size of XML to preview in characters (~100KB). XML preview module can NOT be collapsed by default so we should not have a preview for large files.
 })
 
 useHeadSafe({


### PR DESCRIPTION
After discussing with @geoffreyaldebert , we decided to increase the size limit of JSON files that can have a JSON preview to 1,000,000 characters instead of previously 100,000 chars (~1MB instead of ~100KB).

JSON preview is partly collapsed by default, so that should not degrade user experience - which is not the case with XML preview.