### PR TITLE
fix: fix preview errors by using resource.url instead of resource.latest in all preview components

### DIFF
--- a/datagouv-components/src/components/ResourceAccordion/JsonPreview.vue
+++ b/datagouv-components/src/components/ResourceAccordion/JsonPreview.vue
@@ -120,7 +120,7 @@ const fetchJsonData = async () => {
   error.value = null
 
   try {
-    const response = await fetch(props.resource.latest)
+    const response = await fetch(props.resource.url)
     // const response = await fetch('/test-data.json') // For testing locally without CORS issues
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)

--- a/datagouv-components/src/components/ResourceAccordion/PdfPreview.vue
+++ b/datagouv-components/src/components/ResourceAccordion/PdfPreview.vue
@@ -2,7 +2,7 @@
   <div class="text-xs">
     <div v-if="pdfData">
       <PDF
-        :src="props.resource.latest"
+        :src="props.resource.url"
         :show-progress="true"
         progress-color="#0063cb"
         :show-page-tooltip="true"
@@ -121,7 +121,7 @@ const loadPdf = async () => {
 
   try {
     // Test if the PDF URL is accessible
-    const response = await fetch(props.resource.latest, { method: 'HEAD' })
+    const response = await fetch(props.resource.url, { method: 'HEAD' })
     // const response = await fetch('/test-data.pdf') // For testing locally without CORS issues
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)

--- a/datagouv-components/src/components/ResourceAccordion/PdfPreview.vue
+++ b/datagouv-components/src/components/ResourceAccordion/PdfPreview.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="text-xs">
     <div v-if="pdfData">
+      <!--
+      We use props.resource.url instead of props.resource.latest
+      because the PDF component raises an error otherwise.
+      See https://github.com/datagouv/cdata/pull/611
+      -->
       <PDF
         :src="props.resource.url"
         :show-progress="true"

--- a/datagouv-components/src/components/ResourceAccordion/XmlPreview.vue
+++ b/datagouv-components/src/components/ResourceAccordion/XmlPreview.vue
@@ -110,7 +110,7 @@ const fetchXmlData = async () => {
   error.value = null
 
   try {
-    const response = await fetch(props.resource.latest)
+    const response = await fetch(props.resource.url)
     // const response = await fetch('/test-data.xml') // For testing locally without CORS issues
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`)


### PR DESCRIPTION
Error on PDF preview:
<img width="730" height="110" alt="image" src="https://github.com/user-attachments/assets/af7799b2-8d39-49ac-aa3f-0efbf6794ff2" />

Conversation: https://mattermost.incubateur.net/betagouv/pl/bru4wnh93b8nzcnzh73reigqmh

Fix preview errors by using `resource.url` instead of `resource.latest` in all preview components.