### PR TITLE
Show recommendation source and reason

### DIFF
--- a/components/RecommendationExternal.vue
+++ b/components/RecommendationExternal.vue
@@ -45,7 +45,6 @@ const recommendation = computed(() => {
   const recommendation = recommendations[0]
 
   const locale = shortLocale.value in recommendation.messages ? shortLocale.value : 'fr'
-
   return {
     id: recommendation.id,
     title: recommendation.messages[locale].title,

--- a/components/RecommendationExternal.vue
+++ b/components/RecommendationExternal.vue
@@ -31,6 +31,7 @@
 <script setup lang="ts">
 import { BrandedButton, type DatasetV2WithFullObject } from '@datagouv/components-next'
 import { RiExternalLinkFill } from '@remixicon/vue'
+import type { ExternalRecommendation } from '~/types/recommendations'
 
 const props = defineProps<{ dataset: DatasetV2WithFullObject }>()
 
@@ -38,7 +39,7 @@ const { locale } = useI18n()
 const shortLocale = computed(() => locale.value.split('-')[0])
 
 const recommendation = computed(() => {
-  const recommendations = props.dataset.extras['recommendations-externals'] || null
+  const recommendations = props.dataset.extras['recommendations-externals'] as Array<ExternalRecommendation> || null
   if (!recommendations || !recommendations.length) return
 
   const recommendation = recommendations[0]

--- a/components/RecommendationsDatasets.vue
+++ b/components/RecommendationsDatasets.vue
@@ -1,46 +1,52 @@
 <template>
-  <div
-    v-if="datasetsIds.length"
-    class="space-y-1"
-  >
-    <div class="uppercase text-gray-plain text-sm font-bold">
-      {{ $t('{n} jeux de données recommandés | {n} jeu de données recommandé | {n} jeux de données recommandés', { n: datasetsIds.length }) }}
+  <div>
+    <div
+      v-for="(recommendations, source) in datasetsIdsBySource"
+      :key="source"
+      class="space-y-1"
+    >
+      <div class="uppercase text-gray-plain text-sm font-bold">
+        {{ $t('1 jeu de données recommandé ') }}
+        {{ getRecommendationReason(recommendations[0]) }}
+      </div>
+      <ul class="space-y-4 mt-2 p-0 border-t border-gray-default relative z-2 list-none">
+        <li
+          v-for="recommendation in recommendations"
+          :key="recommendation.id"
+          class="p-0"
+        >
+          <EmbedsDatasetCard
+            :slug="recommendation.id"
+          />
+        </li>
+      </ul>
     </div>
-    <ul class="space-y-4 mt-2 p-0 border-t border-gray-default relative z-2 list-none">
-      <li
-        v-for="recommendationDataset in datasets"
-        :key="recommendationDataset.id"
-        class="p-0"
-        data-track-content
-        data-content-name="dataset recommendations"
-        :data-content-piece="recommendationDataset.title"
-        :data-content-target="recommendationDataset.page"
-      >
-        <DatasetCardLg :dataset="recommendationDataset" />
-      </li>
-    </ul>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { DatasetV2 } from '@datagouv/components-next'
+import type { Recommendation } from '~/types/recommendations'
 
 const props = defineProps<{ dataset: DatasetV2 }>()
 
-const datasets = ref<Record<string, DatasetV2>>({})
+const { getRecommendationReason } = useRecommendationReason()
 
-const datasetsIds = computed(() => {
-  const recommendations = props.dataset.extras['recommendations'] || null
-  if (!recommendations || !recommendations.length) return []
+const datasetsIdsBySource = computed(() => {
+  const recommendations = props.dataset.extras['recommendations'] as Array<Recommendation> || null
+  if (!recommendations || !recommendations.length) return {}
 
-  return recommendations.map((r: { id: string }) => r.id)
-})
-
-const { $api } = useNuxtApp()
-watchEffect(async () => {
-  for (const id of datasetsIds.value) {
-    if (id in datasets.value) return
-    datasets.value[id] = await $api<DatasetV2>(`/api/2/datasets/${id}/`)
-  }
+  return recommendations.reduce((acc, r) => {
+    if (!acc[r.source]) {
+      acc[r.source] = []
+    }
+    if (!r.type) {
+      r.type = 'dataset'
+    }
+    if (r.type === 'dataset') {
+      acc[r.source].push(r)
+    }
+    return acc
+  }, {} as Record<string, Array<Recommendation>>)
 })
 </script>

--- a/components/RecommendationsDatasets.vue
+++ b/components/RecommendationsDatasets.vue
@@ -6,8 +6,8 @@
       class="space-y-1"
     >
       <div class="uppercase text-gray-plain text-sm font-bold">
-        {{ $t('1 jeu de données recommandé ') }}
-        {{ getRecommendationReason(recommendations[0]) }}
+        {{ $t('1 jeu de données recommandé  | {n} jeux de données recommandés ', { n: recommendations.length }) }}
+        {{ getRecommendationReason(recommendations[0], recommendations.length) }}
       </div>
       <ul class="space-y-4 mt-2 p-0 border-t border-gray-default relative z-2 list-none">
         <li

--- a/composables/useRecommendationReason.ts
+++ b/composables/useRecommendationReason.ts
@@ -5,14 +5,10 @@ export function useRecommendationReason() {
   const config = useRuntimeConfig()
   const getRecommendationReason = (recommendation: Recommendation) => {
     switch (recommendation.source) {
-      case 'matomo':
-        return t('car fréquemment visité par les autres visiteurs')
       case 'edito':
         return t(`par l'équipe de {site}`, { site: config.public.title })
-      case 'schema':
+      case 'schemas':
         return t('car conforme au schéma {schéma}', { schema: recommendation.reason })
-      case 'local':
-        return t('car consolidé au niveau national')
       default:
         throwOnNever(recommendation.source, 'Unknown source')
     }

--- a/composables/useRecommendationReason.ts
+++ b/composables/useRecommendationReason.ts
@@ -1,0 +1,21 @@
+import type { Recommendation } from '~/types/recommendations'
+
+export function useRecommendationReason() {
+  const { t } = useI18n()
+  const config = useRuntimeConfig()
+  const getRecommendationReason = (recommendation: Recommendation) => {
+    switch (recommendation.source) {
+      case 'matomo':
+        return t('car fréquemment visité par les autres visiteurs')
+      case 'edito':
+        return t(`par l'équipe de {site}`, { site: config.public.title })
+      case 'schema':
+        return t('car conforme au schéma {schéma}', { schema: recommendation.reason })
+      case 'local':
+        return t('car consolidé au niveau national')
+      default:
+        throwOnNever(recommendation.source, 'Unknown source')
+    }
+  }
+  return { getRecommendationReason }
+}

--- a/composables/useRecommendationReason.ts
+++ b/composables/useRecommendationReason.ts
@@ -3,12 +3,12 @@ import type { Recommendation } from '~/types/recommendations'
 export function useRecommendationReason() {
   const { t } = useI18n()
   const config = useRuntimeConfig()
-  const getRecommendationReason = (recommendation: Recommendation) => {
+  const getRecommendationReason = (recommendation: Recommendation, count: number) => {
     switch (recommendation.source) {
       case 'edito':
         return t(`par l'équipe de {site}`, { site: config.public.title })
       case 'schemas':
-        return t('car conforme au schéma {schéma}', { schema: recommendation.reason })
+        return t('car conforme au schéma {schéma} | car conformes au schéma {schéma}', { schema: recommendation.reason, count })
       default:
         throwOnNever(recommendation.source, 'Unknown source')
     }

--- a/pages/datasets/[did]/index.vue
+++ b/pages/datasets/[did]/index.vue
@@ -36,11 +36,11 @@
       class="space-y-1"
     >
       <div class="uppercase text-gray-plain text-sm font-bold">
-        {{ $t('{n} {label}', { n: data.value.total, label: getResourceLabel(RESOURCE_TYPE[index]) }) }}
+        {{ $t('{n} {label}', { n: data.value?.total, label: getResourceLabel(RESOURCE_TYPE[index]) }) }}
       </div>
       <div class="space-y-2.5">
         <SearchInput
-          v-if="data.value.total > data.value.page_size || searchByResourceType[index].value"
+          v-if="data.value?.total > data.value.page_size || searchByResourceType[index].value"
           v-model="searchByResourceType[index].value"
           :placeholder="$t('Rechercher')"
         />

--- a/types/recommendations.ts
+++ b/types/recommendations.ts
@@ -1,0 +1,18 @@
+export type Recommendation = {
+  id: string
+  score: number
+  source: string
+  reason: string
+  type: 'external' | 'dataset' | 'reuse'
+}
+
+export type ExternalRecommendation = Recommendation & {
+  type: 'external'
+  messages: {
+    [locale: string]: {
+      title: string
+      message: string
+      button: string
+    }
+  }
+}

--- a/types/recommendations.ts
+++ b/types/recommendations.ts
@@ -1,7 +1,7 @@
 export type Recommendation = {
   id: string
   score: number
-  source: 'matomo' | 'edito' | 'schema' | 'local'
+  source: 'edito' | 'schemas'
   reason: string
   type?: 'external' | 'dataset' | 'reuse'
 }

--- a/types/recommendations.ts
+++ b/types/recommendations.ts
@@ -1,9 +1,9 @@
 export type Recommendation = {
   id: string
   score: number
-  source: string
+  source: 'matomo' | 'edito' | 'schema' | 'local'
   reason: string
-  type: 'external' | 'dataset' | 'reuse'
+  type?: 'external' | 'dataset' | 'reuse'
 }
 
 export type ExternalRecommendation = Recommendation & {


### PR DESCRIPTION
Closes https://github.com/datagouv/data.gouv.fr/issues/1827

This PR groups the recommendations by source with a corresponding label.

We can do the same for reuses and dataservices in later PRs.