### PR TITLE
Fix dataset recommandation wording

### DIFF
--- a/composables/useRecommendationReason.ts
+++ b/composables/useRecommendationReason.ts
@@ -8,7 +8,7 @@ export function useRecommendationReason() {
       case 'edito':
         return t(`par l'équipe de {site}`, { site: config.public.title })
       case 'schemas':
-        return t('car conforme au schéma {schéma} | car conformes au schéma {schéma}', { schema: recommendation.reason, count })
+        return t('car conforme au schéma de données | car conformes aux schémas de données', { count })
       default:
         throwOnNever(recommendation.source, 'Unknown source')
     }


### PR DESCRIPTION
See [broken page](https://dev.data.gouv.fr/datasets/liste-des-points-de-charge-pour-vehicules-electriques-1/) due to recommendations ([sentry error](https://errors.data.gouv.fr/organizations/sentry/issues/265278/?environment=dev.data.gouv.fr&project=30&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=0&utc=true)).

The i18n was broken due to `{schéma}`.
We don't have the reason (ie. schema) at this moment in any case...