### PR TITLE
Do not send form on search

### DIFF
--- a/components/Dataservices/SearchPage.vue
+++ b/components/Dataservices/SearchPage.vue
@@ -3,7 +3,7 @@
     v-if="!organization || organization.metrics.dataservices"
     class="group/form"
     data-input-color="blue"
-    @submit.prevent
+    @submit.prevent="() => refresh()"
   >
     <div
       ref="search"
@@ -214,7 +214,7 @@ const nonFalsyParams = computed(() => {
   return { ...propsParams, ...Object.fromEntries(filteredParams), page_size: pageSize }
 })
 
-const { data: searchResults, status: searchResultsStatus } = await useAPI<PaginatedArray<Dataservice>>('/api/2/dataservices/search/', {
+const { data: searchResults, status: searchResultsStatus, refresh } = await useAPI<PaginatedArray<Dataservice>>('/api/2/dataservices/search/', {
   params: nonFalsyParams,
   lazy: true,
 })

--- a/components/Dataservices/SearchPage.vue
+++ b/components/Dataservices/SearchPage.vue
@@ -3,6 +3,7 @@
     v-if="!organization || organization.metrics.dataservices"
     class="group/form"
     data-input-color="blue"
+    @submit.prevent
   >
     <div
       ref="search"

--- a/components/Datasets/SearchPage.vue
+++ b/components/Datasets/SearchPage.vue
@@ -3,6 +3,7 @@
     v-if="!organization || organization.metrics.datasets"
     class="group/form"
     data-input-color="blue"
+    @submit.prevent
   >
     <div
       ref="search"

--- a/components/Datasets/SearchPage.vue
+++ b/components/Datasets/SearchPage.vue
@@ -3,7 +3,7 @@
     v-if="!organization || organization.metrics.datasets"
     class="group/form"
     data-input-color="blue"
-    @submit.prevent
+    @submit.prevent="() => refresh()"
   >
     <div
       ref="search"
@@ -321,7 +321,7 @@ const nonFalsyParams = computed(() => {
   return { ...propsParams, ...Object.fromEntries(filteredParams), page_size: pageSize }
 })
 
-const { data: searchResults, status: searchResultsStatus } = await useAPI<PaginatedArray<DatasetV2>>('/api/2/datasets/search/', {
+const { data: searchResults, status: searchResultsStatus, refresh } = await useAPI<PaginatedArray<DatasetV2>>('/api/2/datasets/search/', {
   params: nonFalsyParams,
   lazy: true,
 })


### PR DESCRIPTION
Since the search is live (without refresh) we don't need to send the form on clic.