### PR TITLE
Fix tooltips height in oembeds

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -2,7 +2,10 @@
   <NuxtLoadingIndicator color="var(--blue-cumulus-main-526)" />
   <NuxtRouteAnnouncer />
   <NuxtLayout>
-    <div id="tooltips" />
+    <div
+      id="tooltips"
+      class="h-0"
+    />
     <NuxtPage />
   </NuxtLayout>
 </template>


### PR DESCRIPTION
following https://github.com/datagouv/cdata/pull/647

There is the same problem in the oembeds since they use a different layout and the `#tooltips` div is just below the `#__nuxt` one.  Instead of trying of moving the `#tooltips` again, I just force the height as 0px.