### PR TITLE
Fix extra accordion in udata-front-kit

### DIFF
--- a/datagouv-components/src/components/ExtraAccordion.vue
+++ b/datagouv-components/src/components/ExtraAccordion.vue
@@ -33,10 +33,7 @@
         </DisclosureButton>
       </div>
     </header>
-    <DisclosurePanel
-      :id="accordionId"
-      class="accordion-content"
-    >
+    <DisclosurePanel :id="accordionId">
       <div class="pb-6 mb-6 border-bottom border-gray-default">
         <div
           class="fr-grid-row fr-grid-row--gutters fr-text--sm fr-m-0"


### PR DESCRIPTION
Our old `@datagouv/components` contains CSS for `accordion-content` to hide content, we aren't using it anymore so we must remove it.

Somehow, with Nuxt the problematic CSS rule is not applying on cdata but it breaks our `<ResourceAccordion/>` in udata-front-kit.