### PR TITLE
Fix wrong imports

### DIFF
--- a/components/Support/Choices.vue
+++ b/components/Support/Choices.vue
@@ -99,9 +99,8 @@
 </template>
 
 <script setup lang="ts">
-import { BrandedButton, SimpleBanner } from '@datagouv/components-next'
+import { useActiveDescendant, BrandedButton, SimpleBanner } from '@datagouv/components-next'
 import MarkdownViewer from '~/components/MarkdownViewer/MarkdownViewer.vue'
-import useActiveDescendant from '~/datagouv-components/src/composables/useActiveDescendant'
 import type { Question, QuestionWithSegment } from '~/types/support'
 
 const emit = defineEmits<{

--- a/datagouv-components/src/components/DatasetInformationPanel.vue
+++ b/datagouv-components/src/components/DatasetInformationPanel.vue
@@ -154,7 +154,7 @@ import type { Granularity } from '../types/granularity'
 import type { Frequency } from '../types/frequency'
 import type { License } from '../types/licenses'
 import { useFetch } from '../functions/api'
-import getDatasetOEmbedHtml from '../functions/datasets'
+import { getDatasetOEmbedHtml } from '../functions/datasets'
 import ExtraAccordion from './ExtraAccordion.vue'
 import CopyButton from './CopyButton.vue'
 

--- a/datagouv-components/src/composables/useActiveDescendant.ts
+++ b/datagouv-components/src/composables/useActiveDescendant.ts
@@ -5,7 +5,7 @@ export type Option = {
   id: string
 }
 
-export default function useActiveDescendant<T extends Option>(options: MaybeRefOrGetter<Array<T>>, direction: 'horizontal' | 'vertical') {
+export function useActiveDescendant<T extends Option>(options: MaybeRefOrGetter<Array<T>>, direction: 'horizontal' | 'vertical') {
   const active = ref<string | undefined>()
 
   const activeOption = computed<T | undefined>(() => toValue(options).find(option => option.id === active.value))

--- a/datagouv-components/src/functions/datasets.ts
+++ b/datagouv-components/src/functions/datasets.ts
@@ -8,7 +8,7 @@ function constructUrl(baseUrl: string, path: string): string {
   return url.toString()
 }
 
-export default function getDatasetOEmbedHtml(type: string, id: string): string {
+export function getDatasetOEmbedHtml(type: string, id: string): string {
   const config = useComponentsConfig()
 
   const staticUrl = constructUrl(config.baseUrl, 'oembed.js')

--- a/datagouv-components/src/functions/organizations.ts
+++ b/datagouv-components/src/functions/organizations.ts
@@ -91,7 +91,7 @@ export function isOrganizationCertified(organization: Organization | null): bool
   return hasBadge(organization, CERTIFIED) && (isType(organization, PUBLIC_SERVICE) || isType(organization, LOCAL_AUTHORITY))
 }
 
-export default function getOrganizationOEmbedHtml(type: string, id: string): string {
+export function getOrganizationOEmbedHtml(type: string, id: string): string {
   const config = useComponentsConfig()
 
   const staticUrl = constructUrl(config.baseUrl, 'oembed.js')

--- a/datagouv-components/src/main.ts
+++ b/datagouv-components/src/main.ts
@@ -33,6 +33,7 @@ import DatasetQualityInline from './components/DatasetQualityInline.vue'
 import DatasetQualityItem from './components/DatasetQualityItem.vue'
 import DatasetQualityScore from './components/DatasetQualityScore.vue'
 import DatasetQualityTooltipContent from './components/DatasetQualityTooltipContent.vue'
+import ExtraAccordion from './components/ExtraAccordion.vue'
 import OrganizationCard from './components/OrganizationCard.vue'
 import OrganizationNameWithCertificate from './components/OrganizationNameWithCertificate.vue'
 import OwnerType from './components/OwnerType.vue'
@@ -44,26 +45,34 @@ import ResourceAccordion from './components/ResourceAccordion/ResourceAccordion.
 import ResourceIcon from './components/ResourceAccordion/ResourceIcon.vue'
 import Swagger from './components/ResourceAccordion/Swagger.client.vue'
 import ReuseCard from './components/ReuseCard.vue'
+import ReuseDetails from './components/ReuseDetails.vue'
 import SimpleBanner from './components/SimpleBanner.vue'
 import StatBox from './components/StatBox.vue'
+import Tab from './components/Tabs/Tab.vue'
+import TabGroup from './components/Tabs/TabGroup.vue'
+import TabList from './components/Tabs/TabList.vue'
+import TabPanel from './components/Tabs/TabPanel.vue'
+import TabPanels from './components/Tabs/TabPanels.vue'
 import Tooltip from './components/Tooltip.vue'
 import Toggletip from './components/Toggletip.vue'
 import type { UseFetchFunction } from './functions/api.types'
 import { configKey, useComponentsConfig, type PluginConfig } from './config.js'
 
+export * from './composables/useActiveDescendant'
 export * from './composables/useReuseType'
 
-export * from './functions/dates'
-export * from './functions/organizations'
-export * from './functions/resources'
-export * from './functions/users'
 export * from './functions/datasets'
-export * from './functions/owned'
+export * from './functions/dates'
 export * from './functions/helpers'
+export * from './functions/markdown'
 export * from './functions/matomo'
 export * from './functions/never'
+export * from './functions/organizations'
+export * from './functions/owned'
+export * from './functions/resources'
+export * from './functions/reuses'
 export * from './functions/schemas'
-export * from './functions/markdown'
+export * from './functions/users'
 
 export type {
   UseFetchFunction,
@@ -159,6 +168,7 @@ export {
   DatasetQualityScore,
   DatasetQualityTooltipContent,
   DateRangeDetails,
+  ExtraAccordion,
   OrganizationCard,
   OrganizationNameWithCertificate,
   OwnerType,
@@ -169,9 +179,15 @@ export {
   ResourceAccordion,
   ResourceIcon,
   ReuseCard,
+  ReuseDetails,
   SimpleBanner,
   StatBox,
   Swagger,
+  Tab,
+  TabGroup,
+  TabList,
+  TabPanel,
+  TabPanels,
   Tooltip,
   Toggletip,
 }

--- a/pages/admin/topics/[id]/datasets.vue
+++ b/pages/admin/topics/[id]/datasets.vue
@@ -75,10 +75,9 @@
 
 <script setup lang="ts">
 import type { Dataset, DatasetV2, TopicV2 } from '@datagouv/components-next'
-import { BrandedButton } from '@datagouv/components-next'
+import { BrandedButton, Pagination } from '@datagouv/components-next'
 import { RiAddLine, RiDeleteBinLine } from '@remixicon/vue'
 import AdminDatasetsTable from '~/components/AdminTable/AdminDatasetsTable/AdminDatasetsTable.vue'
-import Pagination from '~/datagouv-components/src/components/Pagination.vue'
 import type { PaginatedArray } from '~/types/types'
 
 const props = defineProps<{

--- a/pages/admin/topics/[id]/reuses.vue
+++ b/pages/admin/topics/[id]/reuses.vue
@@ -75,11 +75,10 @@
 
 <script setup lang="ts">
 import type { Reuse, TopicV2 } from '@datagouv/components-next'
-import { BrandedButton } from '@datagouv/components-next'
+import { BrandedButton, Pagination } from '@datagouv/components-next'
 import { RiAddLine, RiDeleteBinLine } from '@remixicon/vue'
 import AdminReusesTable from '~/components/AdminTable/AdminReusesTable/AdminReusesTable.vue'
 import ReusesSelect from '~/components/ReusesSelect.vue'
-import Pagination from '~/datagouv-components/src/components/Pagination.vue'
 import type { PaginatedArray } from '~/types/types'
 
 const props = defineProps<{

--- a/pages/datasets/[did]/informations.vue
+++ b/pages/datasets/[did]/informations.vue
@@ -193,11 +193,9 @@
 </template>
 
 <script setup lang="ts">
-import { BrandedButton, CopyButton, DateRangeDetails, useFormatDate, type DatasetV2WithFullObject, type Schema } from '@datagouv/components-next'
+import { BrandedButton, CopyButton, DateRangeDetails, ExtraAccordion, getDatasetOEmbedHtml, useFormatDate, type DatasetV2WithFullObject, type Schema } from '@datagouv/components-next'
 import { RiBook2Line, RiCheckboxCircleLine, RiServerLine } from '@remixicon/vue'
 import LeafletMapClient from '~/components/LeafletMap.client.vue'
-import ExtraAccordion from '~/datagouv-components/src/components/ExtraAccordion.vue'
-import getDatasetOEmbedHtml from '~/datagouv-components/src/functions/datasets'
 
 const props = defineProps<{ dataset: DatasetV2WithFullObject }>()
 

--- a/pages/organizations/[oid]/information.vue
+++ b/pages/organizations/[oid]/information.vue
@@ -276,11 +276,10 @@
 </template>
 
 <script setup lang="ts">
-import { Avatar, BrandedButton, CopyButton, OrganizationNameWithCertificate, StatBox, useFormatDate, type Organization } from '@datagouv/components-next'
+import { Avatar, BrandedButton, CopyButton, OrganizationNameWithCertificate, StatBox, getOrganizationOEmbedHtml, useFormatDate, type Organization } from '@datagouv/components-next'
 import { RiCheckLine, RiDownloadLine, RiTeamLine } from '@remixicon/vue'
 import Divider from '~/components/Divider.vue'
 import type { MembershipRequest, PendingMembershipRequest } from '~/types/types'
-import getOrganizationOEmbedHtml from '~/datagouv-components/src/functions/organizations'
 
 const props = defineProps<{
   organization: Organization

--- a/pages/products/[id]/index.vue
+++ b/pages/products/[id]/index.vue
@@ -281,16 +281,12 @@
 </template>
 
 <script setup lang="ts">
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@datagouv/components-next'
 import { ref, computed, onMounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import Breadcrumb from '~/components/Breadcrumb/Breadcrumb.vue'
 import BreadcrumbItem from '~/components/Breadcrumbs/BreadcrumbItem.vue'
 import BrandCard from '~/components/Brand/BrandCard.vue'
-import TabGroup from '~/datagouv-components/src/components/Tabs/TabGroup.vue'
-import TabList from '~/datagouv-components/src/components/Tabs/TabList.vue'
-import Tab from '~/datagouv-components/src/components/Tabs/Tab.vue'
-import TabPanels from '~/datagouv-components/src/components/Tabs/TabPanels.vue'
-import TabPanel from '~/datagouv-components/src/components/Tabs/TabPanel.vue'
 import DatasetCard from '~/components/Embeds/DatasetCard.global.vue'
 import GristTableViewer from '~/components/GristTableViewer/GristTableViewer.vue'
 

--- a/pages/reuses/[rid].vue
+++ b/pages/reuses/[rid].vue
@@ -165,13 +165,12 @@
 </template>
 
 <script setup lang="ts">
-import { isOrganizationCertified, Avatar, BrandedButton, OrganizationNameWithCertificate, type Reuse } from '@datagouv/components-next'
+import { isOrganizationCertified, Avatar, BrandedButton, OrganizationNameWithCertificate, ReuseDetails, type Reuse } from '@datagouv/components-next'
 import { RiDeleteBinLine, RiLockLine } from '@remixicon/vue'
 import AdminBadge from '~/components/AdminBadge/AdminBadge.vue'
 import EditButton from '~/components/Buttons/EditButton.vue'
 import BreadcrumbItem from '~/components/Breadcrumbs/BreadcrumbItem.vue'
 import ReportModal from '~/components/Spam/ReportModal.vue'
-import ReuseDetails from '~/datagouv-components/src/components/ReuseDetails.vue'
 
 const route = useRoute()
 

--- a/pages/reuses/[rid]/index.vue
+++ b/pages/reuses/[rid]/index.vue
@@ -142,9 +142,8 @@
 </template>
 
 <script setup lang="ts">
-import { useReuseType, StatBox, type Reuse, type ReuseTopic, type DatasetV2, Pagination, useFormatDate } from '@datagouv/components-next'
+import { getTopic, useReuseType, StatBox, type Reuse, type ReuseTopic, type DatasetV2, Pagination, useFormatDate } from '@datagouv/components-next'
 import ReuseCard from '~/components/Reuses/ReuseCard.vue'
-import { getTopic } from '~/datagouv-components/src/functions/reuses'
 import type { PaginatedArray } from '~/types/types'
 
 const props = defineProps<{


### PR DESCRIPTION
We shouldn't use imports from `~/datagouv-components`, only from `@datagouv/components-next`.

If some export is missing, it should be added to `~/datagouv-components/main.ts` instead.
This is probably VSCode doing smart thing when auto-completing imports.