### PR TITLE
Fix toggletip button

### DIFF
--- a/datagouv-components/src/components/BrandedButton.vue
+++ b/datagouv-components/src/components/BrandedButton.vue
@@ -2,7 +2,6 @@
   <!-- 46 42 32 -->
   <component
     :is="href ? AppLink: 'button'"
-    ref="buttonRef"
     class="inline-flex items-center justify-center rounded-full font-medium border !bg-none !no-underline after:content-none"
     :class="[colors, sizes, removePaddingsIfNoBorders, isDisabled ? '!opacity-50' : '', iconRight && !newTab ? 'flex-row-reverse space-x-reverse' : '']"
     :disabled="isDisabled"
@@ -47,7 +46,6 @@ import {
   inject,
   Text,
   useSlots,
-  useTemplateRef,
 } from 'vue'
 import { RiExternalLinkLine } from '@remixicon/vue'
 import type { RouteLocation } from 'vue-router'
@@ -78,7 +76,6 @@ const props = withDefaults(defineProps<{
 })
 
 const slots = useSlots()
-const ref = useTemplateRef<HTMLAnchorElement | HTMLButtonElement>('buttonRef')
 
 const type = computed(() => {
   if (props.type) return props.type
@@ -179,12 +176,4 @@ function hasSlotContent(slot: Slot | undefined, slotProps = {}): boolean {
     )
   })
 }
-
-function focus() {
-  if (ref.value) {
-    ref.value.focus()
-  }
-}
-
-defineExpose({ focus })
 </script>

--- a/datagouv-components/src/components/BrandedButton.vue
+++ b/datagouv-components/src/components/BrandedButton.vue
@@ -2,6 +2,7 @@
   <!-- 46 42 32 -->
   <component
     :is="href ? AppLink: 'button'"
+    ref="buttonRef"
     class="inline-flex items-center justify-center rounded-full font-medium border !bg-none !no-underline after:content-none"
     :class="[colors, sizes, removePaddingsIfNoBorders, isDisabled ? '!opacity-50' : '', iconRight && !newTab ? 'flex-row-reverse space-x-reverse' : '']"
     :disabled="isDisabled"
@@ -46,6 +47,7 @@ import {
   inject,
   Text,
   useSlots,
+  useTemplateRef,
 } from 'vue'
 import { RiExternalLinkLine } from '@remixicon/vue'
 import type { RouteLocation } from 'vue-router'
@@ -76,6 +78,7 @@ const props = withDefaults(defineProps<{
 })
 
 const slots = useSlots()
+const ref = useTemplateRef<HTMLAnchorElement | HTMLButtonElement>('buttonRef')
 
 const type = computed(() => {
   if (props.type) return props.type
@@ -176,4 +179,12 @@ function hasSlotContent(slot: Slot | undefined, slotProps = {}): boolean {
     )
   })
 }
+
+function focus() {
+  if (ref.value) {
+    ref.value.focus()
+  }
+}
+
+defineExpose({ focus })
 </script>

--- a/datagouv-components/src/components/DatasetQuality.vue
+++ b/datagouv-components/src/components/DatasetQuality.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex items-center">
     <Toggletip
-      :button-props="{ size: '2xs', class: '-ml-2 mt-px', title: $t('Qualité des métadonnées') }"
+      :button-props="{ class: '-ml-2 mt-px', title: $t('Qualité des métadonnées') }"
     >
       <template #toggletip>
         <DatasetQualityTooltipContent :quality />

--- a/datagouv-components/src/components/DatasetQuality.vue
+++ b/datagouv-components/src/components/DatasetQuality.vue
@@ -1,9 +1,8 @@
 <template>
   <div class="flex items-center">
     <Toggletip
-      :button-props="{ size: '2xs', class: '-ml-2 mt-px' }"
+      :button-props="{ size: '2xs', class: '-ml-2 mt-px', title: $t('Qualité des métadonnées') }"
     >
-      {{ $t('Qualité des métadonnées:') }}
       <template #toggletip>
         <DatasetQualityTooltipContent :quality />
       </template>

--- a/datagouv-components/src/components/DatasetQualityInline.vue
+++ b/datagouv-components/src/components/DatasetQualityInline.vue
@@ -2,8 +2,9 @@
   <div class="m-0 flex flex-wrap items-center text-sm text-gray-medium">
     <div class="fr-grid-row fr-grid-row--middle">
       <Toggletip
-        :button-props="{ class: 'relative z-2' }"
+        :button-props="{ class: 'relative z-2 ml-0.5', title: $t('Qualité des métadonnées') }"
       >
+        <RiInformationLine class="size-4" />
         <template #toggletip>
           <DatasetQualityTooltipContent :quality />
         </template>
@@ -19,6 +20,7 @@
 </template>
 
 <script setup lang="ts">
+import { RiInformationLine } from '@remixicon/vue'
 import type { Quality } from '../types/datasets'
 import DatasetQualityScore from './DatasetQualityScore.vue'
 import DatasetQualityTooltipContent from './DatasetQualityTooltipContent.vue'

--- a/datagouv-components/src/components/ResourceAccordion/SchemaBadge.vue
+++ b/datagouv-components/src/components/ResourceAccordion/SchemaBadge.vue
@@ -4,9 +4,10 @@
     class="inline-flex mb-0 items-baseline text-xs"
   >
     <Toggletip
-      :button-props="{ class: 'relative z-2 -ml-3 top-1 -my-3' }"
+      :button-props="{ class: 'relative z-2 -ml-3 top-1 -my-3', title: $t('Schéma de données') }"
       no-margin
     >
+      <RiInformationLine class="size-4" />
       <template #toggletip="{ close }">
         <div class="flex justify-between border-bottom">
           <h5 class="fr-text--sm fr-my-0 fr-p-2v">{{ $t("Schéma de données") }}</h5>
@@ -94,6 +95,7 @@
 </template>
 
 <script setup lang="ts">
+import { RiInformationLine } from '@remixicon/vue'
 import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Resource } from '../../types/resources'

--- a/datagouv-components/src/components/Toggletip.vue
+++ b/datagouv-components/src/components/Toggletip.vue
@@ -13,15 +13,12 @@
       @changed="calculatePanelPosition"
     />
     <PopoverButton
-      color="secondary-softer"
-      :as="BrandedButton"
-      icon-only
-      :icon="RiInformationLine"
-      size="xs"
-      keep-margins-even-without-borders
       v-bind="buttonProps"
+      class="w-8 h-8 rounded-full -outline-offset-2 inline-flex items-center justify-center bg-transparent border-transparent hover:!bg-gray-some"
     >
-      <slot />
+      <slot>
+        <RiInformationLine class="size-5" />
+      </slot>
     </PopoverButton>
 
     <ClientOnly>
@@ -49,7 +46,6 @@
 import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 import { nextTick, onBeforeUnmount, onMounted, onUpdated, ref, useTemplateRef } from 'vue'
 import { RiInformationLine } from '@remixicon/vue'
-import BrandedButton from './BrandedButton.vue'
 import ClientOnly from './ClientOnly.vue'
 import ValueWatcher from './ValueWatcher.vue'
 

--- a/datagouv-components/src/components/Toggletip.vue
+++ b/datagouv-components/src/components/Toggletip.vue
@@ -1,6 +1,7 @@
 <template>
   <Popover
     v-slot="{ open, close }"
+    ref="popover"
     class="relative"
   >
     <!--
@@ -11,17 +12,16 @@
       :value="open"
       @changed="calculatePanelPosition"
     />
-    <PopoverButton ref="button">
-      <BrandedButton
-        color="secondary-softer"
-        icon-only
-        :icon="RiInformationLine"
-        size="xs"
-        keep-margins-even-without-borders
-        v-bind="buttonProps"
-      >
-        <slot />
-      </BrandedButton>
+    <PopoverButton
+      color="secondary-softer"
+      :as="BrandedButton"
+      icon-only
+      :icon="RiInformationLine"
+      size="xs"
+      keep-margins-even-without-borders
+      v-bind="buttonProps"
+    >
+      <slot />
     </PopoverButton>
 
     <ClientOnly>
@@ -58,7 +58,7 @@ defineProps<{
   noMargin?: boolean
 }>()
 
-const buttonRef = useTemplateRef('button')
+const popoverRef = useTemplateRef('popover')
 const panelStyle = ref({})
 
 // Since the parent of the component can have an overflow-hidden
@@ -66,17 +66,17 @@ const panelStyle = ref({})
 // We need to compute the correct position of the tooltip.
 const calculatePanelPosition = () => {
   nextTick(() => {
-    const button = buttonRef.value?.$el || buttonRef.value
+    const popover = popoverRef.value?.$el
 
-    if (!button) {
-      console.error('Cannot find the button of the Toggletip.)')
+    if (!popover) {
+      console.error('Cannot find the popover of the Toggletip.)')
       return
     }
-
-    const buttonRect = button.getBoundingClientRect()
+    console.log(popover)
+    const popoverRect = popover.getBoundingClientRect()
     panelStyle.value = {
-      left: `${buttonRect.left + window.scrollX}px`,
-      top: `${buttonRect.bottom + window.scrollY}px`,
+      left: `${popoverRect.left + window.scrollX}px`,
+      top: `${popoverRect.bottom + window.scrollY}px`,
     }
   })
 }

--- a/datagouv-components/src/types/datasets.ts
+++ b/datagouv-components/src/types/datasets.ts
@@ -69,6 +69,7 @@ export type Dataset = BaseDataset & {
   slug: string
   quality: Quality
   metrics: {
+    dataservices: number
     discussions: number
     discussions_open: number
     followers: number

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -309,7 +309,7 @@ const hasContactPointsWithSpecificRole = computed(() => {
   return dataset.value.contact_points.some(contactPoint => contactPoint.role !== 'contact')
 })
 
-await useJsonLd('dataset', route.params.did)
+await useJsonLd('dataset', route.params.did as string)
 
 onMounted(async () => {
   await redirectLegacyHashes([


### PR DESCRIPTION
Our current Toogletip is putting one button (our BrandedButton) inside another button (the PopoverButton).

This is wrong for semantic, accessibility and lead to strange hover issues.

I didn't found a way to use both components, because the PopoverButton is expecting to be a button and not a Vue component (even if it has a `as` prop to change it).