### PR TITLE
Import fixtures in tests and create a super admin

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           repository: opendatateam/udata
           path: udata
-          ref: improve_init_command_for_ci
+          ref: master
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           repository: opendatateam/udata
           path: udata
-          ref: master
+          ref: improve_init_command_for_ci
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -80,6 +80,10 @@ jobs:
           FS_ROOT = 'fs'
 
           SESSION_COOKIE_SECURE = False
+
+          SECURITY_EMAIL_VALIDATOR_ARGS = {
+              "check_deliverability": False
+          }
           EOF
 
       - name: Initialize udata
@@ -92,6 +96,10 @@ jobs:
 
           # Initialize udata
           udata init
+
+          udata import-fixtures
+
+          udata user create --first-name "Admin" --last-name "User" --email "admin@example.com" --password "@1337Password42" --admin
 
           # Start udata server in background
           inv serve --port=5000 &

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,6 +71,7 @@ jobs:
           SEND_MAIL = False
           SERVER_NAME = 'localhost:5000'
           CACHE_TYPE = 'flask_caching.backends.null'
+          DEFAULT_LANGUAGE = 'fr'
 
           URLS_ALLOW_PRIVATE = True
           URLS_ALLOW_LOCAL = True
@@ -91,6 +92,11 @@ jobs:
         env:
           UDATA_SETTINGS: /home/runner/work/cdata/udata/udata.cfg
         run: |
+          pwd
+          ls
+          cat /home/runner/work/cdata/udata/udata.cfg
+          cat udata.cfg
+
           # Create fs directory
           mkdir -p fs
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,10 +90,6 @@ jobs:
       - name: Initialize udata
         working-directory: udata
         run: |
-          pwd
-          ls
-          cat udata.cfg
-
           # Create fs directory
           mkdir -p fs
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,12 +89,9 @@ jobs:
 
       - name: Initialize udata
         working-directory: udata
-        env:
-          UDATA_SETTINGS: /home/runner/work/cdata/udata/udata.cfg
         run: |
           pwd
           ls
-          cat /home/runner/work/cdata/udata/udata.cfg
           cat udata.cfg
 
           # Create fs directory

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,6 +97,8 @@ jobs:
           # Initialize udata
           udata init
 
+          udata licenses
+          udata spatial load
           udata import-fixtures
 
           udata user create --first-name "Admin" --last-name "User" --email "admin@example.com" --password "@1337Password42" --admin


### PR DESCRIPTION
- [x] Import fixtures in CI
- [x] Create an admin user in CI with static email and password (so we can use it in our tests)
- [x] Use french by default in udata for CI
- [x] Enable `udata.cfg` in CI (was broken, the CI didn't use the file created)
- [x] Disable email verification so we can use example.org emails
- Require https://github.com/opendatateam/udata/pull/3419