### PR TITLE
Fix not showing datasets on dataservices update

### DIFF
--- a/components/Dataservices/AdminUpdateDataserviceDatasetsPage.vue
+++ b/components/Dataservices/AdminUpdateDataserviceDatasetsPage.vue
@@ -17,7 +17,7 @@
 
 <script setup lang="ts">
 import { BrandedButton } from '@datagouv/components-next'
-import type { Dataservice, Dataset, DatasetV2 } from '@datagouv/components-next'
+import type { Dataservice, DatasetV2 } from '@datagouv/components-next'
 import type { DatasetSuggest, PaginatedArray } from '~/types/types'
 
 const { t } = useI18n()
@@ -27,7 +27,7 @@ const { toast } = useToast()
 const route = useRoute()
 const url = computed(() => `/api/1/dataservices/${route.params.id}`)
 const { data: dataservice } = await useAPI<Dataservice>(url, { redirectOn404: true })
-const datasets = ref<Array<Dataset | DatasetV2 | DatasetSuggest>>([])
+const datasets = ref<Array<DatasetV2 | DatasetSuggest>>([])
 const datasetsPage = ref<PaginatedArray<DatasetV2> | null>(null)
 watchEffect(async () => {
   if (!dataservice.value) return

--- a/components/ObjectsSelect.vue
+++ b/components/ObjectsSelect.vue
@@ -148,7 +148,7 @@ const suggest = async (query: string): Promise<Array<TSuggest>> => {
   })
 }
 
-watch(selectedSuggest.value, async () => {
+watch(selectedSuggest, async () => {
   for (const object of selectedSuggest.value) {
     if (object.id in objectsByIds.value) continue
 

--- a/datagouv-components/src/components/Toggletip.vue
+++ b/datagouv-components/src/components/Toggletip.vue
@@ -68,7 +68,6 @@ const calculatePanelPosition = () => {
       console.error('Cannot find the popover of the Toggletip.)')
       return
     }
-    console.log(popover)
     const popoverRect = popover.getBoundingClientRect()
     panelStyle.value = {
       left: `${popoverRect.left + window.scrollX}px`,


### PR DESCRIPTION
The watcher didn't work as expected and didn't retrigger on v-model changes.

- [x] remove one console.log in Tooltip
- [x] fix one TS error referencing Dataset (v1)