### PR TITLE
Update error page

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -1,6 +1,9 @@
 <template>
   <NuxtLayout>
-    <div class="min-h-screen bg-white flex items-center justify-center px-8 md:px-4">
+    <div
+      v-if="error"
+      class="min-h-screen bg-white flex items-center justify-center px-8 md:px-4"
+    >
       <div class="flex flex-col items-center text-center max-w-2xl w-full gap-6">
         <div class="w-37 h-35 flex items-center justify-center md:w-25 md:h-24">
           <img
@@ -119,9 +122,15 @@
             <CopyButton
               :label="$t('Copier le code erreur')"
               :copied-label="$t('Code erreur copié !')"
-              :text="errorMessage"
+              :text="errorMessage || ''"
               class="ml-2"
             />
+            <pre
+              v-if="error.stack"
+              class="text-left"
+            >
+              {{ error.stack }}
+            </pre>
           </p>
         </div>
 

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -340,7 +340,7 @@ const datasetVisitsTotal = ref(0)
 const datasetDownloadsResourcesTotal = ref(0)
 
 watchEffect(async () => {
-  if (!dataset.value.id) return
+  if (!dataset.value || !dataset.value.id) return
   // Fetching last 12 months
   const response = await fetch(`${config.public.metricsApi}/api/datasets/data/?dataset_id__exact=${dataset.value.id}&metric_month__sort=desc&page_size=12`)
   const page = await response.json()


### PR DESCRIPTION
- [x] Add stacktrace for debug (should only be present in dev, I think… I hope…)
- [x] Show nothing if there is no error (prevent the problem with showing a 500 on no errors for a brief time while navigating out of the page). See https://github.com/datagouv/data.gouv.fr/issues/1816#issuecomment-3312323466
- [x] Fix a small bug when visiting a 404 dataset (cannot get ID from null). Maybe related to https://github.com/datagouv/cdata/issues/695