### PR TITLE
Fix contact point with long name

### DIFF
--- a/components/ContactPoint.vue
+++ b/components/ContactPoint.vue
@@ -1,15 +1,21 @@
 <template>
-  <div class="text-sm space-x-2">
-    <component
-      :is="link ? 'a' : 'span'"
-      :href="link"
-      rel="ugc nofollow noopener"
-      :target="link ? '_blank' : undefined"
-      class="text-grey-title truncate overflow-hidden"
+  <div>
+    <div
+      class="text-sm space-x-2"
+      :class="{ inline: !link, flex: link }"
     >
-      {{ label }}
-    </component>
-    <small class="text-grey-medium italic">({{ role }})</small>
+      <component
+        :is="link ? 'a' : 'span'"
+        :href="link"
+        :rel="link ? 'ugc nofollow noopener' : undefined"
+        :target="link ? '_blank' : undefined"
+        class="text-grey-title"
+        :class="{ truncate: link }"
+      >
+        {{ label }}
+      </component>
+      <small class="text-grey-medium italic">({{ role }})</small>
+    </div>
   </div>
 </template>
 

--- a/components/ContactPoint.vue
+++ b/components/ContactPoint.vue
@@ -9,6 +9,7 @@
         :href="link"
         :rel="link ? 'ugc nofollow noopener' : undefined"
         :target="link ? '_blank' : undefined"
+        :title="label"
         class="text-grey-title"
         :class="{ truncate: link }"
       >


### PR DESCRIPTION
On details pages, contact points was adding an horizontal scroll to the page. This PR fixes this with the following behavior :
- if the contact point is a link, cdata truncates the label and shows the label in title
- if the contact point has no link, cdata shows the label on multiple lines