### PR TITLE
Show correct since value in StatBox

### DIFF
--- a/components/Metrics/AdminPage.vue
+++ b/components/Metrics/AdminPage.vue
@@ -13,9 +13,11 @@
     </h1>
 
     <p class="text-sm text-gray-medium my-5">
-      {{ $t('Les statistiques sont comptabilisées à partir de juillet 2022.') }}<br>
-      <span v-if="new Date().getHours() > 7 - 1">{{ $t('Mises à jour ce matin') }}</span>
-      <span v-else>{{ $t('Mises à jour hier') }}</span>
+      {{ $t('Les statistiques sont comptabilisées à partir de ') }}
+      {{ formatDate(config.public.metricsSince, { dateStyle: undefined, year: 'numeric', month: 'long', day: undefined }) }}.
+      <br>
+      <span v-if="new Date().getHours() > 7 - 1">{{ $t('Mises à jour ce matin.') }}</span>
+      <span v-else>{{ $t('Mises à jour hier.') }}</span>
     </p>
 
     <TabLinks
@@ -37,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Organization, User } from '@datagouv/components-next'
+import { useFormatDate, type Organization, type User } from '@datagouv/components-next'
 import AdminBreadcrumb from '~/components/Breadcrumbs/AdminBreadcrumb.vue'
 import BreadcrumbItem from '~/components/Breadcrumbs/BreadcrumbItem.vue'
 
@@ -49,6 +51,9 @@ const props = defineProps<{
 defineEmits<{
   refresh: []
 }>()
+
+const config = useRuntimeConfig()
+const { formatDate } = useFormatDate()
 
 const me = useMe()
 

--- a/datagouv-components/src/components/StatBox.vue
+++ b/datagouv-components/src/components/StatBox.vue
@@ -60,8 +60,12 @@
       </div>
     </div>
     <template v-if="lastValue && lastMonth">
-      <p class="mt-1 mb-0 text-xs">
-        {{ $t('depuis juillet 2022') }}
+      <p
+        v-if="since"
+        class="mt-1 mb-0 text-xs"
+      >
+        {{ t("depuis ") }}
+        {{ formatDate(since, { dateStyle: undefined, year: 'numeric', month: 'short', day: undefined }) }}
       </p>
       <p class="mt-1 mb-0 text-xs text-success-darkest">
         <strong>
@@ -161,6 +165,7 @@ const props = defineProps<{
   type: 'line' | 'bar'
   size?: 'sm'
   summary?: number | null
+  since?: string | null
 }>()
 
 const { t } = useTranslation()

--- a/datagouv-components/src/types/datasets.ts
+++ b/datagouv-components/src/types/datasets.ts
@@ -65,6 +65,10 @@ export type Dataset = BaseDataset & {
   created_at: string
   last_modified: string
   last_update: string
+  internal: {
+    created_at_internal: string
+    last_modified_internal: string
+  }
   uri: string
   slug: string
   quality: Quality

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -50,6 +50,7 @@ export default defineNuxtConfig({
       apiBase: 'http://dev.local:7000',
       frontBase: 'http://dev.local:3000',
       metricsApi: 'https://metric-api.data.gouv.fr',
+      metricsSince: '2022-07-01',
       devApiKey: undefined,
       maxJsonPreviewCharSize: 1000000, // (~1MB)
       maxPdfPreviewByteSize: 10000000, // (10 MB)

--- a/pages/dataservices/[did].vue
+++ b/pages/dataservices/[did].vue
@@ -214,6 +214,7 @@
                   type="line"
                   :summary="metricsViewsTotal"
                   class="mb-8 md:mb-0"
+                  :since="metricsSince"
                 />
               </div>
             </dl>
@@ -316,6 +317,11 @@ const openSwagger = ref(false)
 const accessAudiences = computed(() => (['local_authority_and_administration', 'company_and_association', 'private'] as Array<DataserviceAccessAudienceType>)
   .map(type => dataservice.value.access_audiences.find(a => a.role === type))
   .filter(Boolean) as Array<DataserviceAccessAudience>)
+
+const metricsSince = computed(() => {
+  // max of the start of metrics computing and the creation of the dataservice on the platform
+  return [dataservice.value.created_at, config.public.metricsSince].reduce((max, c) => c > max ? c : max)
+})
 
 const metricsViews = ref<null | Record<string, number>>(null)
 const metricsViewsTotal = ref<null | number>(null)

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -187,6 +187,7 @@
                   size="sm"
                   type="line"
                   :summary="datasetVisitsTotal"
+                  :since="metricsSince"
                 />
                 <StatBox
                   :title="$t('Téléchargements')"
@@ -194,6 +195,7 @@
                   size="sm"
                   type="line"
                   :summary="datasetDownloadsResourcesTotal"
+                  :since="metricsSince"
                 />
               </div>
               <div>
@@ -503,6 +505,11 @@ const badges = computed(() =>
 
 const datasetVisitsTotal = ref(0)
 const datasetDownloadsResourcesTotal = ref(0)
+
+const metricsSince = computed(() => {
+  // max of the start of metrics computing and the creation of the dataset on the platform
+  return [dataset.value.internal.created_at_internal, config.public.metricsSince].reduce((max, c) => c > max ? c : max)
+})
 
 watchEffect(async () => {
   if (!dataset.value || !dataset.value.id) return

--- a/pages/organizations/[oid]/information.vue
+++ b/pages/organizations/[oid]/information.vue
@@ -2,7 +2,8 @@
   <div>
     <div class="flex flex-wrap mb-6">
       <h2 class="text-sm w-full flex-none sm:flex-1 mb-0">
-        {{ $t('Statistiques à partir de juillet 2022') }}
+        {{ $t('Statistiques à partir de ') }}
+        {{ formatDate(config.public.metricsSince, { dateStyle: undefined, year: 'numeric', month: 'long', day: undefined }) }}.
       </h2>
       <div>
         <BrandedButton

--- a/pages/reuses/[rid]/index.vue
+++ b/pages/reuses/[rid]/index.vue
@@ -72,6 +72,7 @@
                 type="line"
                 :summary="metricsViewsTotal"
                 class="mb-8 md:mb-0"
+                :since="metricsSince"
               />
             </div>
           </dl>
@@ -150,6 +151,8 @@ const props = defineProps<{
   reuse: Reuse
 }>()
 
+const config = useRuntimeConfig()
+
 const { formatDate } = useFormatDate()
 
 const { label } = useReuseType(props.reuse.type)
@@ -183,6 +186,11 @@ const { data: reuses, status } = await useAPI<PaginatedArray<Reuse>>(`/api/2/reu
 
 // We want 3 reuses, but we don't want the one from the current page
 const relatedReuses = computed(() => reuses.value.data.filter(r => props.reuse.id != r.id).slice(0, 3))
+
+const metricsSince = computed(() => {
+  // max of the start of metrics computing and the creation of the reuse on the platform
+  return [props.reuse.created_at, config.public.metricsSince].reduce((max, c) => c > max ? c : max)
+})
 
 const metricsViews = ref<null | Record<string, number>>(null)
 const metricsViewsTotal = ref<null | number>(null)


### PR DESCRIPTION
Not every metrics start on July 2022 since some objects have been created more recently.

The since only shows for StatBox with `size="sm"`.
Example cases:
- https://www.data.gouv.fr/datasets/liste-des-permis-de-construire-et-autres-autorisations-durbanisme/informations
- https://www.data.gouv.fr/dataservices/api-sirene-dont-unites-a-diffusion-partielle/
- https://www.data.gouv.fr/reuses/donnees-sur-la-localisation-et-lacces-de-la-population-aux-equipements/