### PR TITLE
fix: custom header not sent

### DIFF
--- a/components/Datasets/AdminUpdateDatasetPage.vue
+++ b/components/Datasets/AdminUpdateDatasetPage.vue
@@ -136,18 +136,17 @@ import type { DatasetForm } from '~/types/types'
 
 const { t } = useTranslation()
 const { $api } = useNuxtApp()
-
+const config = useRuntimeConfig()
 const route = useRoute()
 const { start, finish, isLoading } = useLoadingIndicator()
 
 const { toast } = useToast()
 
-const url = computed(() => `/api/2/datasets/${route.params.id}/`)
-const { data: dataset, refresh } = await useAPI<DatasetV2WithFullObject>(url, {
+const url = computed(() => `${config.public.apiBase}/api/2/datasets/${route.params.id}/`)
+const { data: dataset, refresh } = await useAPI<DatasetV2WithFullObject>(url.value, {
   headers: {
     'X-Get-Datasets-Full-Objects': 'True',
   },
-  redirectOn404: true,
 })
 
 const datasetForm = ref<DatasetForm | null>(null)

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -408,7 +408,7 @@ definePageMeta({
   keepScroll: true,
 })
 
-const url = computed(() => `/api/2/datasets/${route.params.did}/`)
+const url = computed(() => `${config.public.apiBase}/api/2/datasets/${route.params.id}/`)
 const { data: dataset, status } = await useAPI<DatasetV2WithFullObject>(url, {
   headers: {
     'X-Get-Datasets-Full-Objects': 'True',


### PR DESCRIPTION
I don't have a clear understanding of why our custom header is not sent.
Maybe it's related to https://github.com/nuxt/nuxt/issues/33013 or to or usage of `await` in `useAPI` (not recommended).

I think this PR is good enough to allow us to deploy on dev / demo / prod our main branch and in the meantime we should investigate the replacement of our `await` with a promise based approach.