### PR TITLE
Fetch all datasets on admin dataservice update page

### DIFF
--- a/components/Dataservices/AdminUpdateDataserviceDatasetsPage.vue
+++ b/components/Dataservices/AdminUpdateDataserviceDatasetsPage.vue
@@ -18,7 +18,7 @@
 <script setup lang="ts">
 import { BrandedButton } from '@datagouv/components-next'
 import type { Dataservice, DatasetV2 } from '@datagouv/components-next'
-import type { DatasetSuggest, PaginatedArray } from '~/types/types'
+import type { DatasetSuggest } from '~/types/types'
 
 const { t } = useTranslation()
 const { $api } = useNuxtApp()
@@ -28,13 +28,10 @@ const route = useRoute()
 const url = computed(() => `/api/1/dataservices/${route.params.id}`)
 const { data: dataservice } = await useAPI<Dataservice>(url, { redirectOn404: true })
 const datasets = ref<Array<DatasetV2 | DatasetSuggest>>([])
-const datasetsPage = ref<PaginatedArray<DatasetV2> | null>(null)
-watchEffect(async () => {
+watch(dataservice, async () => {
   if (!dataservice.value) return
-  datasetsPage.value = await $api<PaginatedArray<DatasetV2>>(`/api/2/datasets/?dataservice=${dataservice.value.id}`)
-  // TODO use page data to see if there is others datasets linked and add a warning message?
-  datasets.value = datasetsPage.value.data
-})
+  datasets.value = await apiFetchAll<DatasetV2>($api, `/api/2/datasets/?dataservice=${dataservice.value.id}`)
+}, { immediate: true })
 
 const submit = async () => {
   await $api(`/api/1/dataservices/${dataservice.value.id}/`, {

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,5 +1,7 @@
 import type { Organization, User } from '@datagouv/components-next'
 import type { NuxtApp, UseFetchOptions } from 'nuxt/app'
+import type { $Fetch } from 'ofetch'
+import type { PaginatedArray } from '~/types/types'
 /*
   Example : const { data: datasets } = await useAPI<PaginatedArray<Dataset>>('/api/1/datasets')
 */
@@ -85,4 +87,30 @@ export function usePostApiWithCsrf() {
       },
     })
   }
+}
+
+export async function apiFetchAll<T>(
+  api: $Fetch,
+  baseUrl: string,
+) {
+  /**
+     * Wrapper to fetch all paginated data
+     */
+
+  const results: T[] = []
+  let nextPage: string | null = null
+
+  // First query
+  const response = await api<PaginatedArray<T>>(baseUrl)
+  results.push(...response.data)
+  nextPage = response.next_page
+
+  // Pagination
+  while (nextPage) {
+    const newResponse = await api<PaginatedArray<T>>(nextPage)
+    results.push(...newResponse.data)
+    nextPage = newResponse.next_page
+  }
+
+  return results
 }


### PR DESCRIPTION
Make sure we fetch all datasets by paginating elements even if there are more than 20.

Fixes cases of updates that keep only the first previous 20 datasets, for example for https://www.data.gouv.fr/fr/dataservices/api-melodi/.