### PR TITLE
fix: uniformize access type filter labels with API card

### DIFF
--- a/datagouv-components/src/components/Search/Filter/AccessTypeFilter.vue
+++ b/datagouv-components/src/components/Search/Filter/AccessTypeFilter.vue
@@ -31,7 +31,7 @@ const { t } = useTranslation()
 
 const options = [
   { value: 'open', label: t('Téléchargement libre') },
-  { value: 'open_with_account', label: t('Ouvert sous condition') },
-  { value: 'restricted', label: t('Accessible sous habilitation') },
+  { value: 'open_with_account', label: t('Ouvert avec un compte') },
+  { value: 'restricted', label: t('Accès restreint') },
 ]
 </script>


### PR DESCRIPTION
## Description

Uniformizes the "Modalités d'accès" filter labels with the API card (fiche API), as requested in [API-6767](https://linear.app/pole-api/issue/API-6767/uniformiser-les-labels-du-filtre-modalites-dacces-avec-la-fiche-api).

- `Ouvert sous condition` → `Ouvert avec un compte`
- `Accessible sous habilitation` → `Accès restreint`

These now match exactly the labels rendered in `DataserviceCard.vue`. The third option (`Téléchargement libre`) was already consistent and left untouched.

## Changes

- `datagouv-components/src/components/Search/Filter/AccessTypeFilter.vue`

fix https://linear.app/pole-api/issue/API-6767/uniformiser-les-labels-du-filtre-modalites-dacces-avec-la-fiche-api