### PR TITLE
fix: keep filtered listings out of the index and redirect legacy search URLs server-side

### DIFF
--- a/composables/useNoindexWhenFiltered.ts
+++ b/composables/useNoindexWhenFiltered.ts
@@ -1,0 +1,11 @@
+// Keeps the filtered variants of a listing page out of the search index: they are
+// subsets of the bare page, and the filters combine into as many URLs as there are
+// value combinations. `nofollow` on top because those variants are crawled far more
+// than they are visited, and every link they carry is one more URL to fetch.
+export function useNoindexWhenFiltered() {
+  const route = useRoute()
+
+  useSeoMeta({
+    robots: () => Object.keys(route.query).length > 0 ? 'noindex, nofollow' : undefined,
+  })
+}

--- a/middleware/redirect.global.ts
+++ b/middleware/redirect.global.ts
@@ -1,3 +1,29 @@
+type SearchRedirect = {
+  path: string
+  facets: Array<string>
+}
+
+// Editorial pages took over /datasets, /reuses and /dataservices, which used to be the
+// search pages themselves. A facet in the query means the visitor followed one of those
+// old search URLs, which stay indexed and linked from outside. Redirecting from the
+// middleware rather than from the pages makes it a real HTTP redirect: clients that run
+// no JS (crawlers included) reach the results, and the editorial page is never rendered
+// only to be thrown away.
+const SEARCH_REDIRECTS: Record<string, SearchRedirect> = {
+  '/datasets': {
+    path: '/datasets/search',
+    facets: ['q', 'tag', 'format', 'license', 'organization', 'organization_badge', 'geozone', 'granularity', 'schema', 'sort', 'page'],
+  },
+  '/reuses': {
+    path: '/reuses/search',
+    facets: ['q', 'sort', 'tag', 'topic', 'page'],
+  },
+  '/dataservices': {
+    path: '/dataservices/search',
+    facets: ['q', 'sort', 'is_restricted', 'organization', 'page'],
+  },
+}
+
 export default defineNuxtRouteMiddleware((to, _from) => {
   // Strip locale prefix and redirect to version without it
   if (to.path.startsWith('/fr/') || to.path.startsWith('/en/') || to.path.startsWith('/es/')) {
@@ -9,6 +35,13 @@ export default defineNuxtRouteMiddleware((to, _from) => {
   if (to.path.endsWith('/') && to.path.length > 1) {
     const newPath = to.path.replace(/\/+$/, '')
     return navigateTo(to.fullPath.replace(to.path, newPath), {
+      redirectCode: 308,
+    })
+  }
+
+  const searchRedirect = SEARCH_REDIRECTS[to.path]
+  if (searchRedirect && Object.keys(to.query).some(key => searchRedirect.facets.includes(key))) {
+    return navigateTo({ path: searchRedirect.path, query: to.query }, {
       redirectCode: 308,
     })
   }

--- a/pages/dataservices/index.vue
+++ b/pages/dataservices/index.vue
@@ -280,16 +280,6 @@ defineOgImage('MainPage.takumi', {
 
 const route = useRoute()
 
-onMounted(async () => {
-  const hasFacets = Object.keys(route.query).some(key =>
-    ['q', 'sort', 'is_restricted', 'organization', 'page'].includes(key),
-  )
-
-  if (hasFacets) {
-    await navigateTo({ path: '/dataservices/search', query: route.query })
-  }
-})
-
 const { site, blocs: siteBlocs, saveBlocs } = await useSiteBlocs('dataservices_blocs', ['metrics'])
 
 const isEditing = computed(() => route.query.edit === 'true')

--- a/pages/datasets/index.vue
+++ b/pages/datasets/index.vue
@@ -65,17 +65,6 @@ useSeoMeta({
 })
 const route = useRoute()
 
-onMounted(async () => {
-  const hasFacets = Object.keys(route.query).some(key =>
-    ['q', 'tag', 'format', 'license', 'organization', 'organization_badge',
-      'geozone', 'granularity', 'schema', 'sort', 'page'].includes(key),
-  )
-
-  if (hasFacets) {
-    await navigateTo({ path: '/datasets/search', query: route.query })
-  }
-})
-
 const { site, blocs: siteBlocs, saveBlocs } = await useSiteBlocs('datasets_blocs', ['metrics'])
 
 const isEditing = computed(() => route.query.edit === 'true')

--- a/pages/datasets/search.vue
+++ b/pages/datasets/search.vue
@@ -56,9 +56,7 @@ const currentType = computed<SearchType>({
   },
 })
 
-const robots = computed(() => {
-  return Object.keys(route.query).length > 0 ? 'noindex, nofollow' : undefined
-})
+useNoindexWhenFiltered()
 
 const heading = computed(() => {
   switch (currentType.value) {
@@ -104,7 +102,6 @@ useSeoMeta({
   description,
   ogTitle: title,
   ogDescription: description,
-  robots,
 })
 
 const ogTitles: Record<SearchType, string> = {

--- a/pages/explore/cada/index.vue
+++ b/pages/explore/cada/index.vue
@@ -197,13 +197,15 @@ const CADA_DATASET_URL = config.public.cadaDatasetUrl
 
 const { t } = useTranslation()
 
+const route = useRoute()
+
+useNoindexWhenFiltered()
+
 useSeoMeta({
   title: () => t('Avis et conseils de la CADA'),
   description: () =>
     t('Recherchez parmi les avis et conseils rendus par la Commission d\'accès aux documents administratifs.'),
 })
-
-const route = useRoute()
 
 const searchQuery = ref('')
 const currentSearch = ref('')

--- a/pages/reuses/index.vue
+++ b/pages/reuses/index.vue
@@ -195,16 +195,6 @@ defineOgImage('MainPage.takumi', {
 
 const route = useRoute()
 
-onMounted(async () => {
-  const hasFacets = Object.keys(route.query).some(key =>
-    ['q', 'sort', 'tag', 'topic', 'page'].includes(key),
-  )
-
-  if (hasFacets) {
-    await navigateTo({ path: '/reuses/search', query: route.query })
-  }
-})
-
 const { data: topics } = await useAPI<Array<ReuseTopic>>('/api/1/reuses/topics/')
 
 const { site, blocs: siteBlocs, saveBlocs } = await useSiteBlocs('reuses_blocs', ['metrics'])

--- a/tests/legacy/edito_redirects_to_search.spec.ts
+++ b/tests/legacy/edito_redirects_to_search.spec.ts
@@ -28,4 +28,24 @@ test.describe('Search redirections', () => {
       await expect(page).toHaveURL(url)
     })
   })
+
+  // Those old search URLs are still indexed and linked from outside, so the redirect
+  // has to happen over HTTP: a client that runs no JS never gets past the landing page.
+  redirectionCases.forEach(({ from, to }) => {
+    test(`${from} → ${to} without running any JS`, async ({ request }) => {
+      const response = await request.get(from, { maxRedirects: 0 })
+
+      expect(response.status()).toBe(308)
+      const location = new URL(response.headers()['location'], 'http://localhost')
+      expect(location.pathname + location.search).toBe(to)
+    })
+  })
+
+  noRedirectionCases.forEach((url) => {
+    test(`${url} is served as-is without running any JS`, async ({ request }) => {
+      const response = await request.get(url, { maxRedirects: 0 })
+
+      expect(response.status()).toBe(200)
+    })
+  })
 })


### PR DESCRIPTION
`/explore/cada` has received 15M requests in a few days (1.5M/day) and I think it's crawlers indexing all the facets. We need to disable this (same thing as /search)

Also move the old redirect in edito pages to search from `onMounted` to SSR for crawlers too.
