### PR TITLE
feat(CI): generic container registry config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  CONTAINER_REGISTRY_URL: ${{ vars.CONTAINER_REGISTRY_URL }}
+  CONTAINER_REGISTRY_SERVER: ${{ vars.CONTAINER_REGISTRY_SERVER }}
   APP_NAME: ${{ vars.APP_NAME }}
   UDATA_WORKING_DIR: udata
 
@@ -365,18 +365,18 @@ jobs:
           echo "short=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
           echo "long=$GITHUB_SHA" >> $GITHUB_OUTPUT
 
-      - name: Log in to GitLab Container Registry
+      - name: Log in to our Docker Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.CONTAINER_REGISTRY_URL }}
-          username: oauth2
-          password: ${{ secrets.GITLAB_API_TOKEN }}
+          registry: ${{ env.CONTAINER_REGISTRY_SERVER }}
+          username: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+          password: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
 
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.CONTAINER_REGISTRY_URL }}/${{ env.APP_NAME }}
+          images: ${{ env.CONTAINER_REGISTRY_SERVER }}/${{ env.APP_NAME }}
           tags: |
             type=sha,format=short,prefix=
             type=sha,format=long,prefix=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
 
 env:
   CONTAINER_REGISTRY_SERVER: ${{ vars.CONTAINER_REGISTRY_SERVER }}
-  APP_NAME: ${{ vars.APP_NAME }}
+  CONTAINER_REGISTRY_NAMESPACE: ${{ vars.CONTAINER_REGISTRY_NAMESPACE }}
+  CONTAINER_NAME: ${{ vars.CONTAINER_NAME }}
   UDATA_WORKING_DIR: udata
 
 permissions:
@@ -376,7 +377,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.CONTAINER_REGISTRY_SERVER }}/${{ env.APP_NAME }}
+          images: ${{ env.CONTAINER_REGISTRY_SERVER }}/${{ env.CONTAINER_REGISTRY_NAMESPACE }}/${{ env.CONTAINER_NAME }}
           tags: |
             type=sha,format=short,prefix=
             type=sha,format=long,prefix=


### PR DESCRIPTION
Allows to change to a different registry that requires a username config for example.

- [x] Variable and secrets have been set already in Github (they are non-breaking)
- [x] Make sure infra is ready to use the new registry before merging ([check `APP_NAME` in pipeline trigger](https://github.com/datagouv/cdata/blob/61ac4d12e0bb003670b4dc979a1dd4edf52c96b6/.github/workflows/create-deploy-release.yml#L56))
- [x] remove useless `CONTAINER_REGISTRY_URL` var after merging