### PR TITLE
feat: skip the /api/1/me call when no session cookie is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This project uses [pnpm](https://pnpm.io/) instead of npm mostly for security re
 - `NUXT_PUBLIC_SENTRY_DSN`: Sentry DSN for error tracking
 - `NUXT_TEMPLATE_CACHE_DURATION`: Duration for template caching
 - `NUXT_SITE_URL`: Site URL (used for OG tags, sitemap, etc.)
+- `NUXT_SESSION_COOKIE_NAME` / `NUXT_REMEMBER_COOKIE_NAME`: names of the udata session cookies (`SESSION_COOKIE_NAME` and `REMEMBER_COOKIE_NAME` on the backend, defaults `session` and `remember_token`). A request carrying none of them is anonymous and skips the `/api/1/me` call, so a mismatch logs every visitor out.
 
 You can work on `cdata` without a local `udata` backend by pointing to https://demo.data.gouv.fr directly. Create a `.env` file at the root of the project:
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -49,6 +49,13 @@ export default defineNuxtConfig({
   },
 
   runtimeConfig: {
+    // Names of the udata cookies that can carry an authenticated session. When the
+    // incoming request has none of them, the visitor is anonymous and `/api/1/me`
+    // can only answer 401, so we skip the call. Both names are configurable in
+    // udata (`SESSION_COOKIE_NAME`, `REMEMBER_COOKIE_NAME`) and must be kept in
+    // sync here.
+    sessionCookieName: 'session',
+    rememberCookieName: 'remember_token',
     crispIdentifier: '',
     crispKey: '',
     crispWebsiteId: '',

--- a/tests-unit/utils/auth.spec.ts
+++ b/tests-unit/utils/auth.spec.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { loadMe } from '~/utils/auth'
+import type { Me } from '~/utils/auth'
+
+const ME = { id: 'me-id', organizations: [] } as unknown as Me
+
+const fetchMe = vi.fn()
+
+/**
+ * Stub the Nuxt globals `loadMe` relies on, for a request carrying `cookies`.
+ */
+const stubRequest = (cookies: Record<string, string>, { devApiKey }: { devApiKey?: string } = {}) => {
+  vi.stubGlobal('useRuntimeConfig', () => ({
+    sessionCookieName: 'session',
+    rememberCookieName: 'remember_token',
+    public: { apiBase: 'http://api.example.com', devApiKey },
+  }))
+  vi.stubGlobal('useRequestHeader', () => Object.entries(cookies).map(([name, value]) => `${name}=${value}`).join('; ') || undefined)
+  vi.stubGlobal('useCookie', (name: string) => ref(cookies[name] ?? null))
+  vi.stubGlobal('useCurrentOwnedSetters', () => ({ setCurrentOrganization: vi.fn(), setCurrentUser: vi.fn() }))
+  vi.stubGlobal('$fetch', fetchMe)
+}
+
+describe('loadMe', () => {
+  beforeEach(() => {
+    fetchMe.mockReset()
+    fetchMe.mockResolvedValue(ME)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not call the API when the request carries no cookie at all', async () => {
+    stubRequest({})
+    const me = ref(undefined)
+
+    await loadMe(me)
+
+    expect(fetchMe).not.toHaveBeenCalled()
+    expect(me.value).toBe(null)
+  })
+
+  it('does not call the API when the request only carries unrelated cookies', async () => {
+    stubRequest({ '_pk_id.1.1fff': 'abc', 'not_session': '1' })
+    const me = ref(undefined)
+
+    await loadMe(me)
+
+    expect(fetchMe).not.toHaveBeenCalled()
+    expect(me.value).toBe(null)
+  })
+
+  it('calls the API when the session cookie is set', async () => {
+    stubRequest({ session: 'eyJfaWQ' })
+    const me = ref(undefined)
+
+    await loadMe(me)
+
+    expect(fetchMe).toHaveBeenCalledOnce()
+    expect(me.value).toStrictEqual(ME)
+  })
+
+  it('calls the API when only the remember cookie is set, as after a browser restart', async () => {
+    stubRequest({ remember_token: '1|abc' })
+    const me = ref(undefined)
+
+    await loadMe(me)
+
+    expect(fetchMe).toHaveBeenCalledOnce()
+    expect(me.value).toStrictEqual(ME)
+  })
+
+  it('calls the API when the request carries an authentication token instead of a session', async () => {
+    stubRequest({ token: 'a-token' })
+    const me = ref(undefined)
+
+    await loadMe(me)
+
+    expect(fetchMe).toHaveBeenCalledOnce()
+    expect(fetchMe.mock.calls[0][1].headers['Authentication-Token']).toBe('a-token')
+    expect(me.value).toStrictEqual(ME)
+  })
+
+  it('calls the API when a dev API key authenticates the request without any cookie', async () => {
+    stubRequest({}, { devApiKey: 'a-dev-key' })
+    const me = ref(undefined)
+
+    await loadMe(me)
+
+    expect(fetchMe).toHaveBeenCalledOnce()
+    expect(fetchMe.mock.calls[0][1].headers['X-API-KEY']).toBe('a-dev-key')
+    expect(me.value).toStrictEqual(ME)
+  })
+
+  it('sets `me` to null when the API answers with an error', async () => {
+    stubRequest({ session: 'stale-session' })
+    fetchMe.mockRejectedValue(new Error('401 Unauthorized'))
+    const me = ref(undefined)
+
+    await loadMe(me)
+
+    expect(me.value).toBe(null)
+  })
+})

--- a/utils/auth.ts
+++ b/utils/auth.ts
@@ -67,14 +67,24 @@ export const loadMe = async (meState: Ref<Me | null | undefined>) => {
   const token = useToken()
   const { setCurrentOrganization, setCurrentUser } = useCurrentOwnedSetters()
 
+  // The vast majority of server-side renders are for anonymous visitors, for whom
+  // `/api/1/me` can only answer 401. Without any credential in the request we know
+  // the answer without asking. Server-side only: session cookies are HttpOnly, so
+  // the browser cannot tell whether they are set.
+  if (import.meta.server && !token.value && !config.public.devApiKey) {
+    const session = useCookie(config.sessionCookieName).value || useCookie(config.rememberCookieName).value
+    if (!session) {
+      meState.value = null
+      return
+    }
+  }
+
   const headers: Record<string, string> = {}
 
   if (cookie) {
-    // console.log('Cookie is set to ' + cookie)
     headers['cookie'] = cookie
   }
   if (token.value) {
-    // console.log('Token is set to ' + token.value)
     headers['Authentication-Token'] = token.value
   }
   if (config.public.devApiKey) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
       '~': fileURLToPath(new URL('.', import.meta.url)),
     },
   },
+  // Nuxt injects these flags at build time; under vitest we run the server side of
+  // the universal code, which is the only side able to read HttpOnly cookies.
+  define: {
+    'import.meta.server': 'true',
+    'import.meta.client': 'false',
+  },
   test: {
     include: ['tests-unit/**/*.spec.ts'],
     environment: 'node',


### PR DESCRIPTION
[GET /api/1/me](https://www.data.gouv.fr/api/1/me) is the second most used API endpoint because cdata is calling it everytime. Let's just call it for people with a session cookie. About 0,04% of the /api/1/me requests are 200, others are 401…