### PR TITLE
feat: cache /api/1/site instead of calling it on every render

### DIFF
--- a/components/SiteFooter/SiteFooter.vue
+++ b/components/SiteFooter/SiteFooter.vue
@@ -290,7 +290,7 @@
 </template>
 
 <script setup lang="ts">
-import { BrandedButton, type Site } from '@datagouv/components-next'
+import { BrandedButton } from '@datagouv/components-next'
 import { RiBlueskyLine, RiGithubLine, RiLinkedinBoxLine, RiMastodonLine, RiRssLine, RiYoutubeLine } from '@remixicon/vue'
 
 const config = useRuntimeConfig()
@@ -349,5 +349,5 @@ const networkLinks: Array<Link> = [
   { label: 'service-public.fr', link: 'https://www.service-public.fr' },
 ]
 
-const { data: site } = await useAPI<Site>('/api/1/site/')
+const { data: site } = await useSite()
 </script>

--- a/composables/useSite.ts
+++ b/composables/useSite.ts
@@ -1,0 +1,9 @@
+import type { Site } from '@datagouv/components-next'
+
+/**
+ * Site-wide data, read through the cached server route rather than straight from
+ * the API: see `server/routes/nuxt-api/site.get.ts`.
+ */
+export function useSite() {
+  return useFetch<Site>('/nuxt-api/site', { key: 'site' })
+}

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -90,14 +90,13 @@
 </template>
 
 <script setup lang="ts">
-import type { Site } from '@datagouv/components-next'
 import { BrandedButton, SimpleBanner, StatBox } from '@datagouv/components-next'
 import { RiDownloadLine } from '@remixicon/vue'
 import Breadcrumb from '~/components/Breadcrumb/Breadcrumb.vue'
 import BreadcrumbItem from '~/components/Breadcrumbs/BreadcrumbItem.vue'
 
 const config = useRuntimeConfig()
-const { data: site } = await useAPI<Site>('/api/1/site/')
+const { data: site } = await useSite()
 
 const downloadUrl = computed(() => {
   return `${config.public.metricsApi}/api/site/data/csv/?metric_month__sort=asc`

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -644,14 +644,14 @@ const exploreHref = computed(() => {
 // The badge labels are a reference list needed only to name the badges this
 // dataset carries: most datasets carry none, and fetching it for them would be
 // one request per page view for nothing.
-const badgeTranslations = dataset.value?.badges?.length
-  ? (await useFetch('/nuxt-api/dataset-badges')).data
-  : null
+const { data: badgeTranslations } = await useFetch('/nuxt-api/dataset-badges', {
+  immediate: Boolean(dataset.value?.badges?.length),
+})
 
 const badges = computed(() =>
   (dataset.value?.badges ?? []).map<TranslatedBadge>(b => ({
     ...b,
-    label: badgeTranslations?.value?.[b.kind] ?? '',
+    label: badgeTranslations.value?.[b.kind] ?? '',
   })),
 )
 
@@ -676,12 +676,12 @@ const datasetDownloadsResourcesTotal = computed(() => datasetMetrics.value?.down
 
 // Same reasoning as the badge labels above: only a restricted dataset names a
 // reason category, which is 0.3% of them.
-const reasonCategories = dataset.value?.access_type_reason_category
-  ? (await useFetch('/nuxt-api/access-type-reason-categories')).data
-  : null
+const { data: reasonCategories } = await useFetch('/nuxt-api/access-type-reason-categories', {
+  immediate: Boolean(dataset.value?.access_type_reason_category),
+})
 
 const category = computed(() => {
   if (!dataset.value?.access_type_reason_category) return null
-  return reasonCategories?.value?.find(c => c.value === dataset.value?.access_type_reason_category)
+  return reasonCategories.value?.find(c => c.value === dataset.value?.access_type_reason_category)
 })
 </script>

--- a/pages/datasets/[did].vue
+++ b/pages/datasets/[did].vue
@@ -641,14 +641,17 @@ const exploreHref = computed(() => {
   return dataset.value?.resources.total ? `/explore/${dataset.value.slug}` : null
 })
 
-const { data: badgeTranslations } = await useAPI<Record<string, string>>(
-  '/api/1/datasets/badges',
-)
+// The badge labels are a reference list needed only to name the badges this
+// dataset carries: most datasets carry none, and fetching it for them would be
+// one request per page view for nothing.
+const badgeTranslations = dataset.value?.badges?.length
+  ? (await useFetch('/nuxt-api/dataset-badges')).data
+  : null
 
 const badges = computed(() =>
   (dataset.value?.badges ?? []).map<TranslatedBadge>(b => ({
     ...b,
-    label: badgeTranslations.value?.[b.kind] ?? '',
+    label: badgeTranslations?.value?.[b.kind] ?? '',
   })),
 )
 
@@ -671,9 +674,14 @@ const datasetDownloadsResources = computed(() => datasetMetrics.value?.downloads
 const datasetVisitsTotal = computed(() => datasetMetrics.value?.visitsTotal ?? 0)
 const datasetDownloadsResourcesTotal = computed(() => datasetMetrics.value?.downloadsTotal ?? 0)
 
-const { data: categories } = await useAPI<Array<{ value: string, label: string, definition: string }>>('/api/1/access_type/reason_categories/')
+// Same reasoning as the badge labels above: only a restricted dataset names a
+// reason category, which is 0.3% of them.
+const reasonCategories = dataset.value?.access_type_reason_category
+  ? (await useFetch('/nuxt-api/access-type-reason-categories')).data
+  : null
+
 const category = computed(() => {
   if (!dataset.value?.access_type_reason_category) return null
-  return categories.value?.find(c => c.value === dataset.value?.access_type_reason_category)
+  return reasonCategories?.value?.find(c => c.value === dataset.value?.access_type_reason_category)
 })
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -478,9 +478,8 @@
 </template>
 
 <script setup lang="ts">
-import { BrandedButton, summarize, useFormatDate, type Site } from '@datagouv/components-next'
+import { BrandedButton, summarize, useFormatDate, TranslationT } from '@datagouv/components-next'
 import { RiArrowRightLine, RiBardLine, RiLineChartLine, RiNewspaperLine, RiSearchLine, RiVipDiamondLine } from '@remixicon/vue'
-import { TranslationT } from '@datagouv/components-next'
 import type { Post } from '~/types/posts'
 import type { PaginatedArray } from '~/types/types'
 
@@ -499,7 +498,7 @@ useSeoMeta({
 })
 
 const { data: posts } = await useAPI<PaginatedArray<Post>>('/api/1/posts/', { params: { kind: 'news' } })
-const { data: site } = await useAPI<Site>('/api/1/site/')
+const { data: site } = await useSite()
 
 const lastPost = computed(() => {
   if (!posts.value || !posts.value.data.length) return null

--- a/server/routes/nuxt-api/access-type-reason-categories.get.ts
+++ b/server/routes/nuxt-api/access-type-reason-categories.get.ts
@@ -1,0 +1,16 @@
+export type ReasonCategory = {
+  value: string
+  label: string
+  definition: string
+}
+
+/**
+ * Categories a dataset can give as a reason for restricting its access. udata
+ * builds them from the `InspireLimitationCategory` enum of its source code, so
+ * they only ever change when udata is deployed: an hour of cache costs nothing.
+ */
+export default cachedEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+
+  return await $fetch<Array<ReasonCategory>>('/api/1/access_type/reason_categories/', { baseURL: config.public.apiBase })
+}, { maxAge: 3600, swr: false })

--- a/server/routes/nuxt-api/dataset-badges.get.ts
+++ b/server/routes/nuxt-api/dataset-badges.get.ts
@@ -1,0 +1,10 @@
+/**
+ * Labels of the available dataset badges, keyed by kind. udata builds them from a
+ * constant of its source code (`Dataset.available_badges()`), so they only ever
+ * change when udata is deployed: an hour of cache costs nothing.
+ */
+export default cachedEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+
+  return await $fetch<Record<string, string>>('/api/1/datasets/badges/', { baseURL: config.public.apiBase })
+}, { maxAge: 3600, swr: false })

--- a/server/routes/nuxt-api/site.get.ts
+++ b/server/routes/nuxt-api/site.get.ts
@@ -1,0 +1,13 @@
+import type { Site } from '@datagouv/components-next'
+
+/**
+ * Site-wide data: the udata version shown by the footer on every page, and the
+ * counters shown on the homepage. It is identical for every visitor and the
+ * backend refreshes the counters once a day, so it is cached here: one call to
+ * udata per minute instead of one per rendered page.
+ */
+export default cachedEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+
+  return await $fetch<Site>('/api/1/site/', { baseURL: config.public.apiBase })
+}, { maxAge: 60, swr: false })

--- a/tests/datasets/[did].spec.ts
+++ b/tests/datasets/[did].spec.ts
@@ -26,6 +26,11 @@ test('dataset with labels shows label section', async ({ page }) => {
 
   // Check that labels are clickable links
   await expect(labelsList.locator('a')).toHaveCount(1)
+
+  // The label text comes from the badge reference list, which the page only
+  // fetches for datasets that carry badges: a link with an empty label means
+  // that list was not loaded.
+  await expect(labelsList.locator('a')).toHaveText(/Service public de la donnée/)
 })
 
 test('dataset labels have proper tooltips and information', async ({
@@ -84,10 +89,13 @@ test('clicking dataset label navigates to filtered search', async ({
 })
 
 test('dataset without labels does not show label section', async ({ page }) => {
-  await page.goto('/datasets/fichier-des-personnes-decedees')
-  // Check if this dataset has no label section
-  const labelSection = page.getByTestId('labelsList')
-  await expect(labelSection).not.toBeVisible()
+  await page.goto('/datasets/base-adresse-nationale')
+
+  // Assert the dataset page actually rendered: on a 404 the label section would
+  // be missing too, and the test would pass without testing anything.
+  await expect(page.getByRole('heading', { level: 1 })).toContainText('Base Adresse Nationale')
+
+  await expect(page.getByTestId('label-list')).not.toBeVisible()
 })
 
 test('tabs are accessible', async ({ page }) => {


### PR DESCRIPTION
[GET /api/1/site](https://www.data.gouv.fr/api/1/site) is the 3rd most called endpoint in udata with 47M calls. I think we can cache it a lot but I only put 1min to start.