### PR TITLE
fix: mark API links as external so the router stops resolving them as routes

### DIFF
--- a/components/Dataservices/AdminDataservicesPage.vue
+++ b/components/Dataservices/AdminDataservicesPage.vue
@@ -33,6 +33,7 @@
           v-if="organization"
           :href="pageData.total ? `${config.public.apiBase}/api/1/organizations/${organization.id}/dataservices.csv` : undefined"
           size="xs"
+          external
           :icon="RiDownloadLine"
         >
           {{ t('Télécharger le catalogue') }}

--- a/datagouv-components/src/components/Search/GlobalSearch.vue
+++ b/datagouv-components/src/components/Search/GlobalSearch.vue
@@ -228,6 +228,7 @@
               size="sm"
               :icon="RiRssLine"
               icon-only
+              external
               target="_blank"
             />
           </div>


### PR DESCRIPTION
```
[VUE_ROUTER_R0004] No match found for location with path "/api/1/datasets/recent.atom"
├▶ fix: Add a route matching this path or check for typos in the location.
╰▶ see: https://router.vuejs.org/guide/essentials/dynamic-matching.html#Catch-all-404-Not-found-Route
```