### PR TITLE
fix: hydratation mismatch on search menu in mobile

### DIFF
--- a/datagouv-components/src/components/Search/Sidemenu.vue
+++ b/datagouv-components/src/components/Search/Sidemenu.vue
@@ -11,7 +11,10 @@
         :class="{ 'rotate-180': open }"
       />
     </button>
-    <div v-if="open || !isMobile">
+    <!-- Collapsing with CSS rather than `v-if` on a JS media query: the server has no
+         viewport, so it always renders the desktop state and a narrow client would drop
+         the whole panel during hydration. -->
+    <div :class="{ 'hidden md:block': !open }">
       <p
         :id="titleId"
         class="text-sm font-bold leading-tight mb-6 hidden md:block"
@@ -26,13 +29,11 @@
 <script setup lang="ts">
 import { ref, useId } from 'vue'
 import { RiArrowDownSLine } from '@remixicon/vue'
-import { useMediaQuery } from '@vueuse/core'
 
 defineProps<{
   buttonText: string
 }>()
 
 const titleId = useId()
-const isMobile = useMediaQuery('(max-width: 767px)')
 const open = ref(false)
 </script>

--- a/tests/datasets/search.spec.ts
+++ b/tests/datasets/search.spec.ts
@@ -309,6 +309,25 @@ test('switching type resets page and clears a type-scoped custom filter in one g
   expect(url.searchParams.has('page')).toBeFalsy()
 })
 
+test.describe('mobile', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('the collapsed filter panel does not break hydration', async ({ page }) => {
+    // The server has no viewport and always renders the panel expanded. When the
+    // panel was collapsed from a JS media query, a narrow client dropped it from
+    // its vdom and Vue tore the subtree down mid-hydration. The console fixture in
+    // tests/base.ts turns the resulting mismatch into a failure.
+    await page.goto('/datasets/search/?badge=hvd')
+    await page.waitForLoadState('networkidle')
+
+    const badgeFieldset = page.locator('fieldset').filter({ hasText: 'Label de donnée' })
+    await expect(badgeFieldset).toBeHidden()
+
+    await page.getByRole('button', { name: 'Filtres' }).click()
+    await expect(badgeFieldset).toBeVisible()
+  })
+})
+
 test('clicking dataset navigates to detail', async ({ page }) => {
   await page.goto('/datasets/search/')
   // Wait for Vue hydration before clicking NuxtLink (fix flaky test on Firefox)


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/300543/

TypeError
Cannot read properties of null (reading 'nextSibling')