### PR TITLE
fix: fall back gracefully when ?resource_id points at a deleted resource

### DIFF
--- a/components/Datasets/FileEditModalFromQueryString.client.vue
+++ b/components/Datasets/FileEditModalFromQueryString.client.vue
@@ -9,6 +9,8 @@
 
 <script setup lang="ts">
 import type { CommunityResource, Dataset, DatasetV2, Resource, SchemaResponseData } from '@datagouv/components-next'
+import { toast } from '@datagouv/components-next'
+import { FetchError } from 'ofetch'
 import FileEditModal from './FileEditModal.vue'
 import type { CommunityResourceForm, ResourceForm } from '~/types/types'
 
@@ -18,19 +20,32 @@ const props = defineProps<{
 }>()
 
 const { $api } = useNuxtApp()
+const { t } = useTranslation()
 
 const resource = ref<ResourceForm | CommunityResourceForm | null>(null)
 const route = useRoute()
+const router = useRouter()
 
 onMounted(async () => {
   const resourceId = route.query.resource_id
   if (Array.isArray(resourceId) || !resourceId) return
 
-  if (props.dataset) { // this is a dataset's resource
-    resource.value = resourceToForm(await $api<Resource>(`/api/1/datasets/${props.dataset.id}/resources/${resourceId}/`), props.schemas)
+  try {
+    if (props.dataset) { // this is a dataset's resource
+      resource.value = resourceToForm(await $api<Resource>(`/api/1/datasets/${props.dataset.id}/resources/${resourceId}/`), props.schemas)
+    }
+    else { // this is a community resource
+      resource.value = resourceToForm(await $api<CommunityResource>(`/api/1/datasets/community_resources/${resourceId}/`), props.schemas)
+    }
   }
-  else { // this is a community resource
-    resource.value = resourceToForm(await $api<CommunityResource>(`/api/1/datasets/community_resources/${resourceId}/`), props.schemas)
+  catch (e) {
+    // A bookmarked or shared link can carry a `resource_id` that has since been deleted:
+    // tell the user and drop it from the URL instead of crashing the page.
+    if (!(e instanceof FetchError) || e.statusCode !== 404) throw e
+
+    toast.error(t('Ce fichier est introuvable.'))
+    const { resource_id: _, ...query } = route.query
+    router.replace({ query })
   }
 })
 </script>

--- a/components/Datasets/LegacyResourceList.vue
+++ b/components/Datasets/LegacyResourceList.vue
@@ -94,15 +94,18 @@
 </template>
 
 <script setup lang="ts">
-import { BrandedButton, getResourceLabel, LoadingBlock, Pagination, RESOURCE_TYPE, ResourceAccordion, SearchInput, SimpleBanner, type DatasetV2, type Resource } from '@datagouv/components-next'
+import { BrandedButton, getResourceLabel, LoadingBlock, Pagination, RESOURCE_TYPE, ResourceAccordion, SearchInput, SimpleBanner, toast, type DatasetV2, type Resource } from '@datagouv/components-next'
 import { RiCloseCircleLine } from '@remixicon/vue'
 import { refDebounced } from '@vueuse/core'
+import { FetchError } from 'ofetch'
 import type { PaginatedArray } from '~/types/types'
 
 const props = defineProps<{ dataset: DatasetV2 }>()
 
 const config = useRuntimeConfig()
 const route = useRoute()
+const router = useRouter()
+const { t } = useTranslation()
 
 const url = computed(() => `/api/2/datasets/${props.dataset.id}/resources/`)
 const pageSize = ref(10)
@@ -147,14 +150,31 @@ const { $api } = useNuxtApp()
 const selectedResource = ref<Resource | null>(null)
 const selectedResourceBanner = useTemplateRef('selectedResourceBannerRef')
 watchEffect(async () => {
-  if (hasResourceId.value) {
-    selectedResource.value = await $api<Resource>(`/api/1/datasets/${props.dataset.id}/resources/${route.query.resource_id}/`)
-    nextTick(() => {
-      selectedResourceBanner.value?.scrollIntoView({ behavior: 'smooth' })
-    })
-  }
-  else {
+  if (!hasResourceId.value) {
     selectedResource.value = null
+    return
   }
+
+  try {
+    selectedResource.value = await $api<Resource>(`/api/1/datasets/${props.dataset.id}/resources/${route.query.resource_id}/`)
+  }
+  catch (e) {
+    // A bookmarked or shared link can carry a `resource_id` that has since been deleted.
+    // The dataset page itself is still valid, so fall back to the full list of resources
+    // instead of erroring out.
+    if (!(e instanceof FetchError) || e.statusCode !== 404) throw e
+
+    selectedResource.value = null
+    if (import.meta.client) {
+      toast.error(t('Ce fichier est introuvable.'))
+      const { resource_id: _, ...query } = route.query
+      router.replace({ query })
+    }
+    return
+  }
+
+  nextTick(() => {
+    selectedResourceBanner.value?.scrollIntoView({ behavior: 'smooth' })
+  })
 })
 </script>

--- a/tests/datasets/files-management.spec.ts
+++ b/tests/datasets/files-management.spec.ts
@@ -88,6 +88,24 @@ test.describe('Dataset files management', () => {
     await expect(page.locator('tbody tr').filter({ hasText: 'Ressource conservée' })).toBeVisible()
   })
 
+  test('a ?resource_id pointing at a deleted file does not break the page', async ({ page, request }) => {
+    const { dataset } = await createDatasetWithRemoteResources(request, `Test files management ${Date.now()}`, ['Ressource conservée'])
+    createdDatasets.push(dataset.id)
+
+    const pageErrors: Array<Error> = []
+    page.on('pageerror', error => pageErrors.push(error))
+
+    // The link was shared or bookmarked while the file still existed
+    await page.goto(`/admin/datasets/${dataset.id}/files?resource_id=00000000-0000-0000-0000-000000000000`)
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.getByText('Ce fichier est introuvable.')).toBeVisible()
+    await expect(page.getByRole('dialog')).toHaveCount(0)
+    await expect(page).not.toHaveURL(/resource_id=/)
+    await expect(page.locator('tbody tr').filter({ hasText: 'Ressource conservée' })).toBeVisible()
+    expect(pageErrors).toEqual([])
+  })
+
   test('can replace an uploaded file', async ({ page, request }) => {
     const uniqueId = Date.now()
     const dataset = await createDataset(request, `Test files replace ${uniqueId}`, 'Dataset pour tester le remplacement de fichier')

--- a/tests/datasets/resources.spec.ts
+++ b/tests/datasets/resources.spec.ts
@@ -117,6 +117,23 @@ test.describe('Public resources display', () => {
     await expect(page.getByText(resources[0].title)).toBeVisible()
   })
 
+  test('deep-link to a deleted resource falls back to the full list', async ({ page, request }) => {
+    const { dataset, resources } = await createDatasetWithRemoteResources(request, `Test public resources ${Date.now()}`, resourceTitles(2))
+    createdDatasets.push(dataset.id)
+
+    const pageErrors: Array<Error> = []
+    page.on('pageerror', error => pageErrors.push(error))
+
+    // The link was shared or bookmarked while the resource still existed
+    await page.goto(`/datasets/${dataset.id}/?resource_id=00000000-0000-0000-0000-000000000000`)
+
+    await expect(page.getByText('Ce fichier est introuvable.')).toBeVisible()
+    await expect(page.getByText('Vous consultez une resource spécifique.')).not.toBeVisible()
+    await expect(page.getByText(resources[0].title)).toBeVisible()
+    await expect(page).not.toHaveURL(/resource_id=/)
+    expect(pageErrors).toEqual([])
+  })
+
   test('remote resource has a correct download link', async ({ page, request }) => {
     const { dataset, resources } = await createDatasetWithRemoteResources(request, `Test public resources ${Date.now()}`, resourceTitles(1))
     createdDatasets.push(dataset.id)


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/300558

FetchError /admin/datasets/:id()/files
[GET] "https://www.data.gouv.fr/api/1/datasets/68108b02b49b7c6c559e6b71/resources/c5e840fb-3f62-410b-9425-473416e80cb6/?lang=fr": 404 