### PR TITLE
fix: ignore malformed accept-language values instead of passing them to Intl

### DIFF
--- a/datagouv-components/src/composables/useTranslation.ts
+++ b/datagouv-components/src/composables/useTranslation.ts
@@ -14,24 +14,39 @@ const translationModules = import.meta.glob<Record<string, string>>('../../../lo
   import: 'default',
 })
 
+const LANGUAGE_SUBTAG_REGEX = /^[a-z]{2,3}$/
+
+/**
+ * Extract the language subtag of an `accept-language` header or of
+ * `navigator.language`, and return it only if it is a well-formed one.
+ *
+ * Both are user-controlled, and the locale is handed over to `Intl` formatters,
+ * which throw a `RangeError` on anything that is not a valid language tag. The
+ * wildcard `*` is rejected here too: it means "any language", so it must fall
+ * back to the next detection step.
+ */
+function parseLanguage(value: string | undefined | null): string | null {
+  if (!value) {
+    return null
+  }
+  const language = value.split(';')[0]!.split(',')[0]!.split('-')[0]!.toLowerCase()
+  return LANGUAGE_SUBTAG_REGEX.test(language) ? language : null
+}
+
 function detectLanguage(): string {
   // Server-side (Nuxt)
   try {
-    const header = useRequestHeader?.('accept-language')
-    const acceptLanguage = header
-    if (acceptLanguage) {
-      const primaryLang = acceptLanguage.split(';')[0]!.split(',')[0]!.split('-')[0]!.toLowerCase()
-      // Ignore wildcard * language, that should fallback to client side detection or default language
-      if (primaryLang !== '*') return primaryLang
-    }
+    const language = parseLanguage(useRequestHeader?.('accept-language'))
+    if (language) return language
   }
   catch {
     // useRequestHeaders not available, continue to client-side detection
   }
 
   // Client-side
-  if (typeof window !== 'undefined' && navigator.language) {
-    return navigator.language.split('-')[0]!.toLowerCase()
+  if (typeof window !== 'undefined') {
+    const language = parseLanguage(navigator.language)
+    if (language) return language
   }
 
   return 'fr'

--- a/tests-unit/datagouv-components/translation.spec.ts
+++ b/tests-unit/datagouv-components/translation.spec.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useTranslation } from '~/datagouv-components/src/composables/useTranslation'
+
+const withAcceptLanguage = (header: string | undefined) => {
+  vi.stubGlobal('useRequestHeader', (name: string) => name === 'accept-language' ? header : undefined)
+  return useTranslation().locale
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('locale detection', () => {
+  it('uses the language subtag of the accept-language header', () => {
+    expect(withAcceptLanguage('fr')).toEqual('fr')
+    expect(withAcceptLanguage('en-US,en;q=0.9')).toEqual('en')
+    expect(withAcceptLanguage('DE-de')).toEqual('de')
+  })
+
+  it('falls back to french on a header without a usable language', () => {
+    // Regression: a malformed header used to be passed as-is to `Intl`, which
+    // throws a RangeError and made the whole server-side render fail
+    expect(withAcceptLanguage('en_US')).toEqual('fr')
+    expect(withAcceptLanguage('*')).toEqual('fr')
+    expect(withAcceptLanguage(';q=0.9')).toEqual('fr')
+    expect(withAcceptLanguage('1')).toEqual('fr')
+    expect(withAcceptLanguage('')).toEqual('fr')
+    expect(withAcceptLanguage(undefined)).toEqual('fr')
+  })
+
+  it('always returns a locale every Intl formatter accepts', () => {
+    for (const header of ['fr', 'en-US,en;q=0.9', 'en_US', '*', ';q=0.9', '1', '', undefined]) {
+      const locale = withAcceptLanguage(header)
+      expect(() => new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })).not.toThrow()
+      expect(() => new Intl.DateTimeFormat(locale)).not.toThrow()
+      expect(() => new Intl.NumberFormat(locale)).not.toThrow()
+    }
+  })
+})


### PR DESCRIPTION
Fix https://errors.data.gouv.fr/organizations/sentry/issues/300592

Error GET /dataservices/jours-feries
Incorrect locale information provided