### PR TITLE
fix(ci): serialize the datagouv-components publish so overlapping runs stop computing the same version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,12 @@ jobs:
   publish-datagouv-components:
     needs: [quality_and_test, e2e]
     runs-on: ubuntu-latest
+    # The version is read from the `dev` dist-tag then incremented, so two overlapping runs would
+    # compute the same number and the second would get a 403. `queue: max` serializes them FIFO
+    # (up to 100 pending) instead of cancelling the pending one like the default `queue: single`.
+    concurrency:
+      group: publish-datagouv-components
+      queue: max
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Fix the fails on main when two merges are really close