### PR TITLE
fix: prevent duplicate membership acceptance returning a 409

### DIFF
--- a/components/AdminMembershipRequest/AdminMembershipRequest.vue
+++ b/components/AdminMembershipRequest/AdminMembershipRequest.vue
@@ -117,6 +117,7 @@
         color="primary"
         size="xs"
         :icon="RiCheckLine"
+        :loading="loading"
         @click="accept"
       >
         {{ $t('Accepter la demande') }}

--- a/pages/admin/organizations/[oid]/members.vue
+++ b/pages/admin/organizations/[oid]/members.vue
@@ -528,6 +528,11 @@ const isUserAlreadyInvitedOrMember = (user: UserSuggest | null): string | null =
   if (pendingInvitations.value.some(i => i.user?.id === user.id)) {
     return t('Cet utilisateur a déjà été invité')
   }
+  // Inviting someone who already applied would let them join through the invitation
+  // while their request stays pending, and accepting it afterwards answers a 409.
+  if (pendingRequests.value.some(r => r.user?.id === user.id)) {
+    return t('Cet utilisateur a déjà demandé à rejoindre l\'organisation')
+  }
   return null
 }
 
@@ -538,6 +543,9 @@ const isEmailAlreadyInvited = (emailValue: string): string | null => {
   }
   if (organization.value?.members.some(m => m.user.email?.toLowerCase() === emailValue.toLowerCase())) {
     return t('Un membre avec cette adresse email existe déjà')
+  }
+  if (pendingRequests.value.some(r => r.user?.email?.toLowerCase() === emailValue.toLowerCase())) {
+    return t('Cet utilisateur a déjà demandé à rejoindre l\'organisation')
   }
   return null
 }

--- a/tests/organizations/membership-requests.spec.ts
+++ b/tests/organizations/membership-requests.spec.ts
@@ -1,0 +1,77 @@
+import type { Page, Browser } from '@playwright/test'
+import { test, expect } from '../base'
+import { createOrganization, deleteOrganizations } from '../helpers'
+
+const API_BASE = process.env.NUXT_PUBLIC_API_BASE || 'http://dev.local:7000'
+
+// A dedicated organization per test, so the browser projects running in parallel
+// don't fight over the same pending request.
+const organizationWithPendingRequest = async (page: Page, browser: Browser, name: string) => {
+  const org = await createOrganization(page.request, `${name} ${Date.now()}`)
+
+  const normalUserContext = await browser.newContext({ storageState: 'playwright/.auth/normal-user.json' })
+  const normalUserPage = await normalUserContext.newPage()
+  const response = await normalUserPage.request.post(`${API_BASE}/api/1/organizations/${org.id}/membership/`, {
+    data: { comment: 'Please let me in' },
+  })
+  expect(response.ok()).toBe(true)
+  await normalUserContext.close()
+
+  return org
+}
+
+test.describe('Membership requests', () => {
+  test('accepting a request twice in a row only accepts it once', async ({ page, browser }) => {
+    const org = await organizationWithPendingRequest(page, browser, 'Double accept test')
+
+    let acceptCalls = 0
+    await page.route(/\/membership\/[^/]+\/accept/, async (route) => {
+      acceptCalls++
+      await route.continue()
+    })
+
+    try {
+      await page.goto(`/admin/organizations/${org.id}/members`)
+
+      const acceptButton = page.getByRole('button', { name: 'Accepter la demande' })
+      await expect(acceptButton).toBeVisible({ timeout: 10000 })
+
+      // A second accept while the first one is in flight makes the API answer 409
+      // ("already a member"), which surfaces as an unexpected API error toast.
+      await acceptButton.dblclick()
+
+      await expect(page.locator('tr').filter({ hasText: 'Normal User' })).toBeVisible({ timeout: 10000 })
+      await expect(page.getByText('L\'API a retourné une erreur inattendue')).not.toBeVisible()
+      expect(acceptCalls).toBe(1)
+    }
+    finally {
+      await deleteOrganizations(page.request, [org.id])
+    }
+  })
+
+  test('cannot invite someone who already applied to the organization', async ({ page, browser }) => {
+    const org = await organizationWithPendingRequest(page, browser, 'Invite applicant test')
+
+    try {
+      await page.goto(`/admin/organizations/${org.id}/members`)
+      await expect(page.getByRole('button', { name: 'Accepter la demande' })).toBeVisible({ timeout: 10000 })
+
+      await page.getByRole('button', { name: 'Inviter un membre' }).click()
+      await expect(page.getByRole('heading', { name: 'Inviter un membre' })).toBeVisible()
+
+      // A role is needed too, otherwise the submit button stays disabled on its own
+      // and would prove nothing about the pending request.
+      await page.locator('select').selectOption('editor')
+
+      await page.getByTestId('searchable-select-utilisateur').click()
+      await page.getByPlaceholder('Rechercher un utilisateur').fill('Normal')
+      await page.getByRole('option', { name: 'Normal User' }).click()
+
+      await expect(page.getByText('Cet utilisateur a déjà demandé à rejoindre l\'organisation')).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Envoyer l\'invitation' })).toBeDisabled()
+    }
+    finally {
+      await deleteOrganizations(page.request, [org.id])
+    }
+  })
+})


### PR DESCRIPTION
Fix [FetchError](https://errors.data.gouv.fr/organizations/sentry/issues/300649/?referrer=alert_email&alert_type=email&alert_timestamp=1787819461429&alert_rule_id=29&notification_uuid=e1541c74-5ad9-45f2-96ec-cf0fd09aead5&environment=www.data.gouv.fr) /admin/organizations/:oid()/members
[POST] "https://​www.​data.​gouv.​fr/​api/​1/​organizati­ons/​6410a71de7­707043d449­bfa7/​membership/​c3427536...