### PR TITLE
fix: stop crashing on tabular profiles without csv-detective output (parquet)

### DIFF
--- a/datagouv-components/src/components/TabularExplorer/types.ts
+++ b/datagouv-components/src/components/TabularExplorer/types.ts
@@ -24,25 +24,28 @@ export type TabularProfileResponse = {
   indexes: null
 }
 
+// Only CSV resources go through csv-detective: for the other formats the API
+// indexes (parquet…), the profile is reduced to the column names, their types
+// and the row count. Everything csv-detective produces is therefore optional.
 export type TabularProfile = {
   header: string[]
   columns: Record<string, TabularColumnInfo>
-  formats: Record<string, string[]>
-  profile: Record<string, TabularColumnProfile>
-  encoding: string
-  separator: string
-  categorical: string[]
   total_lines: number
-  nb_duplicates: number
-  columns_fields: Record<string, TabularColumnInfo>
-  columns_labels: Record<string, TabularColumnInfo>
-  header_row_idx: number
-  heading_columns: number
-  trailing_columns: number
+  formats?: Record<string, string[]>
+  profile?: Record<string, TabularColumnProfile>
+  encoding?: string
+  separator?: string
+  categorical?: string[]
+  nb_duplicates?: number
+  columns_fields?: Record<string, TabularColumnInfo>
+  columns_labels?: Record<string, TabularColumnInfo>
+  header_row_idx?: number
+  heading_columns?: number
+  trailing_columns?: number
 }
 
 export type TabularColumnInfo = {
-  score: number
+  score?: number
   format: string
   python_type: string
 }

--- a/datagouv-components/src/components/TabularExplorer/useColumnMetadata.ts
+++ b/datagouv-components/src/components/TabularExplorer/useColumnMetadata.ts
@@ -38,7 +38,7 @@ export function useColumnMetadata(
     if (!profile) return 'text'
     const colInfo = profile.columns[col]
     if (!colInfo) return 'text'
-    return resolveColumnType(colInfo, profile.categorical.includes(col))
+    return resolveColumnType(colInfo, profile.categorical?.includes(col) ?? false)
   }
 
   const columnTypesMap = computed<Record<string, ColumnType>>(() => {

--- a/datagouv-components/src/functions/charts.ts
+++ b/datagouv-components/src/functions/charts.ts
@@ -72,13 +72,13 @@ export function toChartApi(chartForm: ChartForm): ChartForApi {
 export function buildColumnsFromProfile(profile: { profile: TabularProfile }): Array<ColumnDefinition> {
   return profile.profile.header.map((name) => {
     const colInfo = profile.profile.columns[name]
-    const isCategorical = profile.profile.categorical.includes(name)
+    const isCategorical = profile.profile.categorical?.includes(name) ?? false
     // The chart stack only branches on 'number' and 'date' (continuous axis,
     // aggregatable series, time formatting): it has no notion of a year column,
     // and on an axis a year is a number.
     const resolvedType = resolveColumnType(colInfo ?? { python_type: 'unknown', format: undefined }, isCategorical)
     const colType = resolvedType === 'year' ? 'number' : resolvedType
-    const colProfile = profile.profile.profile[name]
+    const colProfile = profile.profile.profile?.[name]
     return {
       name,
       type: colType,

--- a/tests-unit/datagouv-components/charts.spec.ts
+++ b/tests-unit/datagouv-components/charts.spec.ts
@@ -167,4 +167,23 @@ describe('buildColumnsFromProfile', () => {
     const createdAtColumn = columns.find(c => c.name === 'created_at')
     expect(createdAtColumn).toEqual({ name: 'created_at', type: 'date', min: undefined, max: undefined })
   })
+
+  // Non-CSV resources (parquet…) are indexed without csv-detective: the profile
+  // only carries the column names, their types and the row count.
+  it('builds columns from a profile without csv-detective output', () => {
+    const parquetProfile: { profile: TabularProfile } = {
+      profile: {
+        header: profile.profile.header,
+        columns: profile.profile.columns,
+        total_lines: profile.profile.total_lines,
+      },
+    }
+    const columns = buildColumnsFromProfile(parquetProfile)
+    expect(columns).toEqual([
+      { name: 'year', type: 'number', min: undefined, max: undefined },
+      { name: 'rate', type: 'number', min: undefined, max: undefined },
+      { name: 'label', type: 'text', min: undefined, max: undefined },
+      { name: 'created_at', type: 'date', min: undefined, max: undefined },
+    ])
+  })
 })

--- a/tests-unit/datagouv-components/column-metadata.spec.ts
+++ b/tests-unit/datagouv-components/column-metadata.spec.ts
@@ -1,0 +1,64 @@
+import { ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { useColumnMetadata } from '~/datagouv-components/src/components/TabularExplorer/useColumnMetadata'
+import type { TabularProfileResponse } from '~/datagouv-components/src/components/TabularExplorer/types'
+import type { TranslationFunction } from '~/datagouv-components/src/composables/useTranslation'
+
+const t: TranslationFunction = key => key
+
+// The profile the API returns for a parquet resource: csv-detective only runs on
+// CSVs, so `categorical`, `profile` and the rest of its output are missing.
+const parquetProfile: TabularProfileResponse = {
+  profile: {
+    header: ['code_insee', 'population'],
+    columns: {
+      code_insee: { format: 'string', python_type: 'string' },
+      population: { format: 'int', python_type: 'int' },
+    },
+    total_lines: 35000,
+  },
+  deleted_at: null,
+  dataset_id: 'dataset-1',
+  indexes: null,
+}
+
+describe('useColumnMetadata on a profile without csv-detective output', () => {
+  const metadata = useColumnMetadata(ref(parquetProfile), ['code_insee', 'population'], t)
+
+  it('resolves types from the python type alone, without a categorical list', () => {
+    expect(metadata.getColumnType('code_insee')).toBe('text')
+    expect(metadata.getColumnType('population')).toBe('number')
+  })
+
+  it('falls back to the type display when no column profile is available', () => {
+    expect(metadata.getColumnDisplay('code_insee').label).toBe('Texte')
+    expect(metadata.getColumnProfile('code_insee')).toBeNull()
+    expect(metadata.getNullPercent('code_insee')).toBe('0%')
+    expect(metadata.getBooleanCounts('code_insee')).toEqual({ trueCount: 0, falseCount: 0 })
+  })
+})
+
+describe('useColumnMetadata on a full csv-detective profile', () => {
+  const csvProfile: TabularProfileResponse = {
+    ...parquetProfile,
+    profile: {
+      ...parquetProfile.profile,
+      categorical: ['code_insee'],
+      formats: {},
+      profile: {
+        code_insee: { tops: [], nb_distinct: 3, nb_missing_values: 3500 },
+        population: { tops: [], nb_distinct: 100, nb_missing_values: 0 },
+      },
+    },
+  }
+  const metadata = useColumnMetadata(ref(csvProfile), ['code_insee', 'population'], t)
+
+  it('marks a column listed as categorical', () => {
+    expect(metadata.getColumnType('code_insee')).toBe('categorical')
+    expect(metadata.getColumnDisplay('code_insee').label).toBe('Catégoriel')
+  })
+
+  it('computes the null ratio from the column profile', () => {
+    expect(metadata.getNullPercent('code_insee')).toBe('10.0%')
+  })
+})


### PR DESCRIPTION
Fix [TypeError](https://errors.data.gouv.fr/organizations/sentry/issues/300708/?referrer=alert_email&alert_type=email&alert_timestamp=1787848154328&alert_rule_id=29&notification_uuid=89e8616e-e472-489b-8cc1-0b0caa3f4d0d&environment=www.data.gouv.fr) /datasets/:did()
Cannot read properties of undefined (reading 'includes')

Can be tested on http://dev.local:3000/explore/communes-et-villes-de-france-en-csv-excel-json-parquet-et-feather?resource_id=4c73a9e2-a543-4ca8-8b10-638cb0f7a613 (with production data)