### PR TITLE
fix: initialize the discussion notification subject to null so it is not undefined while loading

### DIFF
--- a/components/Notifications/NotificationsList.vue
+++ b/components/Notifications/NotificationsList.vue
@@ -62,6 +62,7 @@ watchEffect(async () => {
     if (notification.details.class !== 'DiscussionNotificationDetails' || notification.details.discussion.subject.id in subjectsPromises.value) continue
 
     const id = notification.details.discussion.subject.id
+    subjects.value[id] = null // The subject is rendered before it is fetched, `null` hides it until then
     subjectsPromises.value[id] = getSubject($api, notification.details.discussion.subject)
       .then((subject) => {
         subjects.value[id] = subject // Working because there is no conflicts between IDs from different types


### PR DESCRIPTION
```
[Vue warn]: Invalid prop: type check failed for prop "subject". Expected Object | Null, got Undefined  
  at <NotificationsDiscussion key=3 notification= 
Object { created_at: "2026-08-26T18:12:57.953000+00:00", details: {…}, handled_at: null, id: "53f3bdf3-dbe8-4aad-9787-ba8b46998d27", last_modified: "2026-08-26T18:13:48.340000+00:00", user: {…} }
 
subject=undefined > 
  at <NotificationsList key=0 notifications= 
Array(10) [ {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…}, {…} ]
 
> 
  at <PopoverPanel ref="panel" class="drop-shadow bg-white rounded-sm w-96 absolute z-[800] p-0" style= 
Object { position: "absolute", left: "0", top: "0" }
 
 ... > 
  at <ClientOnly key=0 > 
  at <ClientOnly> 
  at <PortalWrapper > 
  at <Popover ref="popover" class="relative" > 
  at <Toggletip key=0 button-props= 
Object { class: "px-1 text-xs h-5 gap-1 font-bold rounded-sm text-danger bg-danger-lightest", title: "Voir les notifications - 74 nouvelle | Voir les notifications - 74 nouvelles" }
 
no-margin=""  ... > 
  at <ClientOnly key=0 > 
  at <SiteHeader> 
  at <Default ref=Ref< 
Proxy { <target>: Proxy, <handler>: {…} }
 
> > 
  at <AsyncComponentWrapper ref=Ref< 
Proxy { <target>: Proxy, <handler>: {…} }
 
> > 
  at <LayoutLoader key="default" layoutProps= 
Object { ref: {…} }
 
name="default" > 
  at <NuxtLayoutProvider layoutProps= 
Object { ref: {…} }
 
key="default" name="default"  ... > 
  at <NuxtLayout> 
  at <App key=4 > 
  at <NuxtRoot>
  ```