### PR TITLE
fix(ci): stamp Sentry debug IDs during the build so uploaded source maps match the deployed bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Build application
         run: NUXT_APP_COMMIT_ID=$(git rev-parse --short HEAD) pnpm run build
 
+      # Injection rewrites the bundles and shifts their source maps by the same amount, so it
+      # has to happen on the artifact everyone downloads. Done in the `sentry` job instead, it
+      # would only ever touch a copy that is never deployed, and the maps would be uploaded
+      # two lines off. No credentials needed: the command only writes ids into the files.
+      - name: Inject Sentry debug IDs
+        run: pnpm dlx @sentry/cli sourcemaps inject .output/public/_nuxt
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -421,6 +428,10 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_URL: ${{ secrets.SENTRY_URL }}
         with:
+          # Injection happens during the build, on the artifact this job downloads. Letting
+          # the action do it here would rewrite its own copy and upload maps two lines off
+          # from the deployed bundles.
+          inject: false
           sourcemaps: ".output/public/_nuxt"
           url_prefix: "~/_nuxt"
           environment: ${{ github.ref_name }}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -410,7 +410,10 @@ export default defineNuxtConfig({
   },
   sentry: {
     sourceMapsUploadOptions: {
-      // disable sourcemaps upload from build, it's done later during the release with sentry-cli
+      // Keeping the bundler plugin out also keeps it from stamping its own debug id: it only
+      // writes one as a runtime snippet, never the `//# debugId=` comment and the matching
+      // key in the map that an upload pairs on, so it would compete with the id the CI build
+      // injects rather than replace it. Upload is done during the release with sentry-cli.
       enabled: false,
     },
   },
@@ -431,6 +434,4 @@ export default defineNuxtConfig({
 
     // TODO: add /support pages
   },
-  // TODO: add sentry config for stack traces based on source maps
-  // https://docs.sentry.io/platforms/javascript/guides/nuxt/#add-readable-stack-traces-to-errors
 })


### PR DESCRIPTION
Sentry resolved every frame 2 lines too early, so the `Cannot destructure property 'bum'` crash pointed at `prepareAnchor` (Teleport) instead of `unmountComponent`. Cause: `getsentry/action-release` injects the debug ids in its own job, on a copy `docker` had already taken, so the uploaded maps never matched the deployed bundles.

Injecting after the build can't work either: Nitro records each asset's size and pre-compresses it, so rewriting `.output/public` afterwards serves a truncated script. So the bundler plugin does it during `renderChunk`, and uploads too, since that's when it writes the `//# debugId=` and the matching map key. The `sentry` job goes away, and the token only reaches `main` and manual runs, so PR builds inject and upload nothing.
