### PR TITLE
fix: use the flask-caching 2.5 backend class name for the CI null cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           SERVER_NAME = 'localhost:7000'
           CDATA_BASE_URL="http://localhost:3000"
 
-          CACHE_TYPE = 'null'
+          CACHE_TYPE = 'flask_caching.backends.NullCache'
           DEFAULT_LANGUAGE = 'fr'
 
           SCHEMA_CATALOG_URL='https://schema.data.gouv.fr/schemas/schemas.json'


### PR DESCRIPTION
Require since https://github.com/opendatateam/udata/pull/3921