### PR TITLE
feat(resource): resourceExternalUrl as prop

### DIFF
--- a/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
+++ b/datagouv-components/src/components/ResourceAccordion/ResourceAccordion.vue
@@ -47,7 +47,7 @@
           <CopyButton
             :label="t('Copier le lien')"
             :copied-label="t('Lien copié !')"
-            :text="resourceExternalUrl"
+            :text="externalUrl"
             class="z-2"
           />
         </div>
@@ -327,7 +327,7 @@ import { trackEvent } from '../../functions/matomo'
 import CopyButton from '../CopyButton.vue'
 import { useComponentsConfig } from '../../config'
 import { getOwnerName } from '../../functions/owned'
-import { getResourceFormatIcon, getResourceTitleId, detectOgcService, getResourceExternalUrl, getResourceFilesize, isImagePreviewFormat } from '../../functions/resources'
+import { getResourceFormatIcon, getResourceTitleId, detectOgcService, getResourceFilesize, isImagePreviewFormat, resolveResourceExternalUrl } from '../../functions/resources'
 import BrandedButton from '../BrandedButton.vue'
 import { useTranslation } from '../../composables/useTranslation'
 import { useHasTabularData } from '../../composables/useHasTabularData'
@@ -349,6 +349,8 @@ const props = withDefaults(defineProps<{
   isCommunityResource?: boolean
   resource: Resource | CommunityResource
   canEdit?: boolean
+  // Overrides the "Copier le lien" target.
+  resourceExternalUrl?: (resource: Resource | CommunityResource) => string
 }>(), {
   expandedOnMount: false,
   isCommunityResource: false,
@@ -468,7 +470,7 @@ const resourceFilesize = computed(() => getResourceFilesize(props.resource))
 const unavailable = availabilityChecked && props.resource.extras['check:available'] === false
 const downloadButtonTitle = unavailable ? t(`Le robot de {certifier} n'a pas pu accéder à ce fichier - Télécharger le fichier en {format}`, { certifier: config.name, format: format.value }) : t(`Télécharger le fichier en {format}`, { format: format.value })
 
-const resourceExternalUrl = computed(() => getResourceExternalUrl(props.dataset, props.resource))
+const externalUrl = computed(() => resolveResourceExternalUrl(props.dataset, props.resource, props.resourceExternalUrl))
 
 const resourceContentId = 'resource-' + props.resource.id
 const resourceHeaderId = 'resource-' + props.resource.id + '-header'

--- a/datagouv-components/src/components/ResourceExplorer/ResourceExplorer.vue
+++ b/datagouv-components/src/components/ResourceExplorer/ResourceExplorer.vue
@@ -49,6 +49,7 @@
             :resources="flatResources"
             :resource-to="resourceTo"
             :explore-to="exploreTo"
+            :resource-external-url="resourceExternalUrl"
             replace
             :fullscreen
           />
@@ -59,6 +60,7 @@
               :resources="flatResources"
               :resource-to="resourceTo"
               :explore-to="exploreTo"
+              :resource-external-url="resourceExternalUrl"
               replace
               :fullscreen
             />
@@ -122,6 +124,8 @@ const props = withDefaults(defineProps<{
   // Inline mode only: link builder for the "Explorer" button in the viewer header
   // that opens the fullscreen explorer on the current resource.
   exploreTo?: (resource: Resource) => string
+  // Overrides the "Copier le lien" target.
+  resourceExternalUrl?: (resource: Resource) => string
 }>(), {
   noResultsImage: '',
   fullscreen: false,

--- a/datagouv-components/src/components/ResourceExplorer/ResourceExplorerViewer.vue
+++ b/datagouv-components/src/components/ResourceExplorer/ResourceExplorerViewer.vue
@@ -6,6 +6,7 @@
       :resources
       :resource-to
       :explore-to="exploreTo"
+      :resource-external-url="resourceExternalUrl"
       :replace
       :fullscreen
     />
@@ -217,6 +218,8 @@ const props = withDefaults(defineProps<{
   // When provided (inline mode), shows an "Explorer" button next to the download
   // action that opens the fullscreen explorer on the current resource.
   exploreTo?: (resource: Resource) => string
+  // Overrides the "Copier le lien" target.
+  resourceExternalUrl?: (resource: Resource) => string
   replace?: boolean
   // Fullscreen mode: make the viewer a flex column so the table fills down to the
   // bottom, and hide the inline download/visit/copy actions — they're shown in the

--- a/datagouv-components/src/components/ResourceExplorer/ResourceViewerHeader.vue
+++ b/datagouv-components/src/components/ResourceExplorer/ResourceViewerHeader.vue
@@ -53,7 +53,7 @@
       <CopyButton
         :label="t('Copier le lien')"
         :copied-label="t('Lien copié !')"
-        :text="resourceExternalUrl"
+        :text="externalUrl"
         icon-only
         class="hidden shrink-0 md:inline-flex"
       />
@@ -94,7 +94,7 @@ import ResourceMainAction from './ResourceMainAction.vue'
 import FormattedDate from '../FormattedDate.vue'
 import TranslationT from '../TranslationT.vue'
 import { filesize, summarize } from '../../functions/helpers'
-import { getResourceExternalUrl, getResourceFilesize } from '../../functions/resources'
+import { getResourceFilesize, resolveResourceExternalUrl } from '../../functions/resources'
 import { trackEvent } from '../../functions/matomo'
 import { useTranslation } from '../../composables/useTranslation'
 import type { RouteLocationRaw } from 'vue-router'
@@ -110,6 +110,8 @@ const props = defineProps<{
   resources?: Resource[]
   resourceTo?: (resource: Resource) => RouteLocationRaw
   exploreTo?: (resource: Resource) => string
+  // Overrides the "Copier le lien" target.
+  resourceExternalUrl?: (resource: Resource) => string
   replace?: boolean
   // Fullscreen mode hides the inline actions — they live in the dataset context bar above.
   fullscreen?: boolean
@@ -118,5 +120,5 @@ const props = defineProps<{
 const { t } = useTranslation()
 
 const resourceFilesize = computed(() => getResourceFilesize(props.resource))
-const resourceExternalUrl = computed(() => getResourceExternalUrl(props.dataset, props.resource))
+const externalUrl = computed(() => resolveResourceExternalUrl(props.dataset, props.resource, props.resourceExternalUrl))
 </script>

--- a/datagouv-components/src/components/ResourceExplorer/ResourceViewerSkeleton.vue
+++ b/datagouv-components/src/components/ResourceExplorer/ResourceViewerSkeleton.vue
@@ -9,6 +9,7 @@
       :resources
       :resource-to
       :explore-to="exploreTo"
+      :resource-external-url="resourceExternalUrl"
       :replace
       :fullscreen
     />
@@ -80,6 +81,7 @@ const props = defineProps<{
   resources?: Resource[]
   resourceTo?: (resource: Resource) => RouteLocationRaw
   exploreTo?: (resource: Resource) => string
+  resourceExternalUrl?: (resource: Resource) => string
   replace?: boolean
   fullscreen?: boolean
 }>()

--- a/datagouv-components/src/config.ts
+++ b/datagouv-components/src/config.ts
@@ -1,8 +1,6 @@
 import { inject, type Component, type InjectionKey } from 'vue'
 import type { UseFetchFunction } from './functions/api.types'
 import type { $Fetch, FetchOptions } from 'ofetch'
-import type { Dataset, DatasetV2 } from './types/datasets'
-import type { CommunityResource, Resource } from './types/resources'
 
 export type PluginConfig = {
   name: string // Name of the application (ex: data.gouv.fr)
@@ -47,12 +45,6 @@ export type PluginConfig = {
   clientOnly?: Component | null
   searchDebounce?: number
   forumUrl?: string
-  /**
-   * Overrides the "Copier le lien" target built by `getResourceExternalUrl`.
-   * Must return an absolute URL: it is copied to the clipboard and used as an
-   * external, `_blank` link target.
-   */
-  getResourceExternalUrl?: (dataset: Dataset | DatasetV2 | Omit<Dataset, 'resources' | 'community_resources'>, resource: Resource | CommunityResource) => string
 }
 
 export const configKey = Symbol() as InjectionKey<PluginConfig>

--- a/datagouv-components/src/functions/resources.ts
+++ b/datagouv-components/src/functions/resources.ts
@@ -179,8 +179,6 @@ export function getResourceExternalUrl(dataset: Dataset | DatasetV2 | Omit<Datas
   return `${dataset.page}${isCommunityResource(resource) ? '/community-resources' : ''}?resource_id=${resource.id}`
 }
 
-// Shared by every "Copier le lien" call site (ResourceViewerHeader, ResourceAccordion): resolves
-// the caller's `resourceExternalUrl` prop override, falling back to the default external URL.
 export function resolveResourceExternalUrl<R extends Resource | CommunityResource>(
   dataset: Dataset | DatasetV2 | Omit<Dataset, 'resources' | 'community_resources'>,
   resource: R,

--- a/datagouv-components/src/functions/resources.ts
+++ b/datagouv-components/src/functions/resources.ts
@@ -176,10 +176,17 @@ export function isCommunityResource(resource: Resource | CommunityResource): boo
 }
 
 export function getResourceExternalUrl(dataset: Dataset | DatasetV2 | Omit<Dataset, 'resources' | 'community_resources'>, resource: Resource | CommunityResource): string {
-  const config = useComponentsConfig()
-  if (config.getResourceExternalUrl) return config.getResourceExternalUrl(dataset, resource)
-
   return `${dataset.page}${isCommunityResource(resource) ? '/community-resources' : ''}?resource_id=${resource.id}`
+}
+
+// Shared by every "Copier le lien" call site (ResourceViewerHeader, ResourceAccordion): resolves
+// the caller's `resourceExternalUrl` prop override, falling back to the default external URL.
+export function resolveResourceExternalUrl<R extends Resource | CommunityResource>(
+  dataset: Dataset | DatasetV2 | Omit<Dataset, 'resources' | 'community_resources'>,
+  resource: R,
+  override?: (resource: R) => string,
+): string {
+  return override ? override(resource) : getResourceExternalUrl(dataset, resource)
 }
 
 export function getResourceFilesize(resource: Resource): null | number {


### PR DESCRIPTION
Follow up #1215 
Related https://github.com/opendatateam/udata-front-kit/pull/1373

I've been too eager to follow the review comments there. We actually need prop rather than config downstream: the component is mounted in different contexts/pages and thus a prop is better suited to configure the component.

This removes the config key and adds the props. It also handles `ResourceAccordion.vue` that was left out before.